### PR TITLE
Fix Gini Impurity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - 2.5.6
     - Fix Batch Norm normalize over batch size not features
+    - Fix Classification Tree Gini impurity calculation
 
 - 2.5.5
     - Add numerical stability to logsumexp function

--- a/src/Classifiers/ClassificationTree.php
+++ b/src/Classifiers/ClassificationTree.php
@@ -236,7 +236,13 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
             $probabilities[$class] = $count / $n;
         }
 
-        $impurity = 1.0 - ($counts[$outcome] / $n) ** 2;
+        $ss = 0.0;
+
+        foreach ($counts as $count) {
+            $ss += ($count / $n) ** 2;
+        }
+
+        $impurity = 1.0 - $ss;
 
         return new Best($outcome, $probabilities, $impurity, $n);
     }
@@ -257,13 +263,13 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
 
         $counts = array_count_values($labels);
 
-        $gini = 0.0;
+        $ss = 0.0;
 
         foreach ($counts as $count) {
-            $gini += 1.0 - ($count / $n) ** 2;
+            $ss += ($count / $n) ** 2;
         }
 
-        return $gini;
+        return 1.0 - $ss;
     }
 
     /**

--- a/src/Classifiers/ClassificationTree.php
+++ b/src/Classifiers/ClassificationTree.php
@@ -231,15 +231,14 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
         $outcome = argmax($counts);
 
         $probabilities = [];
-
-        foreach ($counts as $class => $count) {
-            $probabilities[$class] = $count / $n;
-        }
-
         $ss = 0.0;
 
-        foreach ($counts as $count) {
-            $ss += ($count / $n) ** 2;
+        foreach ($counts as $class => $count) {
+            $probability = $count / $n;
+
+            $ss += $probability ** 2;
+
+            $probabilities[$class] = $probability;
         }
 
         $impurity = 1.0 - $ss;
@@ -248,7 +247,7 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
     }
 
     /**
-     * Calculate the impurity of a set of labels.
+     * Calculate the impurity of a set of labels using gini coefficient.
      *
      * @param list<string|int> $labels
      * @return float
@@ -269,7 +268,9 @@ class ClassificationTree extends CART implements Estimator, Learner, Probabilist
             $ss += ($count / $n) ** 2;
         }
 
-        return 1.0 - $ss;
+        $impurity = 1.0 - $ss;
+
+        return $impurity;
     }
 
     /**


### PR DESCRIPTION
src/Classifiers/ClassificationTree.php:260-266 accumulates 1 - (count/n)² per class, so for k classes present it returns k - Σpᵢ². Correct Gini impurity is 1 - Σpᵢ². The extra k-1 makes impurity() return up to k-1 too high, and because k varies per candidate subset, it distorts:

Split selection — DecisionTree::splitImpurity() (DecisionTree.php:396) picks the argmin of weighted per-node impurities.
Pruning — Split::purityIncrease() (Split.php:135) and the gate in DecisionTree::grow() (DecisionTree.php:219).
Feature importances — DecisionTree::featureImportances() (DecisionTree.php:296).
This is real, not a constant offset: different candidate splits partition into different k, so the bias changes the ordering. Git history (commit 77b9f93b "Fixed gini impurity computation") shows the canonical form was Σpᵢ² then 1 - Σpᵢ² — later regression reintroduced the per-class 1-pᵢ².