### PR TITLE
Fix Batch Norm NumPower version

### DIFF
--- a/src/NeuralNet/Layers/BatchNorm.php
+++ b/src/NeuralNet/Layers/BatchNorm.php
@@ -231,7 +231,10 @@ class BatchNorm implements Hidden, Parametric
         $this->stdInv = $stdInv;
         $this->xHat = $xHat;
 
-        return NumPower::add(NumPower::multiply($xHat, $this->gamma->param()), $this->beta->param());
+        $gamma = NumPower::reshape($this->gamma->param(), [$n, 1]);
+        $beta = NumPower::reshape($this->beta->param(), [$n, 1]);
+
+        return NumPower::add(NumPower::multiply($xHat, $gamma), $beta);
     }
 
     /**
@@ -258,12 +261,12 @@ class BatchNorm implements Hidden, Parametric
             NumPower::reshape(NumPower::sqrt($varianceClipped), [$n, 1])
         );
 
+        $gamma = NumPower::reshape($this->gamma->param(), [$n, 1]);
+        $beta = NumPower::reshape($this->beta->param(), [$n, 1]);
+
         return NumPower::add(
-            NumPower::multiply(
-                $xHat,
-                $this->gamma->param()
-            ),
-            $this->beta->param()
+            NumPower::multiply($xHat, $gamma),
+            $beta
         );
     }
 
@@ -321,11 +324,12 @@ class BatchNorm implements Hidden, Parametric
      */
     public function gradient(NDArray $dOut, NDArray $gamma, NDArray $stdInv, NDArray $xHat) : NDArray
     {
-        $dXHat = NumPower::multiply($dOut, $gamma);
+        [$n, $m] = $dOut->shape();
+
+        $gammaCol = NumPower::reshape($gamma, [$n, 1]);
+        $dXHat = NumPower::multiply($dOut, $gammaCol);
         $xHatSigma = NumPower::sum(NumPower::multiply($dXHat, $xHat), axis: 1);
         $dXHatSigma = NumPower::sum($dXHat, axis: 1);
-
-        [$n, $m] = $dOut->shape();
 
         // Compute gradient per formula: dX = (dXHat * m - dXHatSigma - xHat * xHatSigma) * (stdInv / m)
         $dXHatTimesM = NumPower::multiply($dXHat, $m);

--- a/tests/Classifiers/MultilayerPerceptronTest.php
+++ b/tests/Classifiers/MultilayerPerceptronTest.php
@@ -13,7 +13,7 @@ use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\Loggers\BlackHole;
 use Rubix\ML\Datasets\Unlabeled;
 use Rubix\ML\NeuralNet\Layers\Dense;
-use Rubix\ML\NeuralNet\Layers\Noise;
+use Rubix\ML\NeuralNet\Layers\BatchNorm;
 use Rubix\ML\NeuralNet\Layers\Dropout;
 use Rubix\ML\NeuralNet\ActivationFunctions\SoftPlus;
 use Rubix\ML\NeuralNet\Layers\Swish;
@@ -93,7 +93,7 @@ class MultilayerPerceptronTest extends TestCase
                 new Dropout(0.1),
                 new Dense(16),
                 new Activation(new SoftPlus()),
-                new Noise(1e-5),
+                new BatchNorm(),
                 new Dense(8),
                 new Swish(),
             ],
@@ -148,7 +148,7 @@ class MultilayerPerceptronTest extends TestCase
                 new Dropout(0.1),
                 new Dense(16),
                 new Activation(new SoftPlus()),
-                new Noise(1e-5),
+                new BatchNorm(),
                 new Dense(8),
                 new Swish(),
             ],

--- a/tests/NeuralNet/Layers/BatchNormTest.php
+++ b/tests/NeuralNet/Layers/BatchNormTest.php
@@ -91,25 +91,27 @@ class BatchNormTest extends TestCase
     }
 
     /**
-     * Additional inputs to validate behavior across different batch sizes.
+     * Non-square inputs: 3 features × varying batch sizes (features=3, samples=k).
      *
      * @return array<string, array{0:array}>
      */
     public static function batchInputsProvider() : array
     {
         return [
-            'batch1x3' => [[
-                [2.0, -1.0, 0.0],
+            '3features_1sample' => [[
+                [2.0],
+                [-1.0],
+                [0.0],
             ]],
-            'batch2x3' => [[
-                [1.0, 2.0, 3.0],
-                [3.0, 3.0, 3.0],
+            '3features_2samples' => [[
+                [1.0, 3.0],
+                [2.0, 3.0],
+                [3.0, 3.0],
             ]],
-            'batch4x3' => [[
-                [0.5, -0.5, 1.5],
-                [10.0, -10.0, 0.0],
-                [7.2, 3.3, -2.4],
-                [-1.0, -2.0, 4.0],
+            '3features_4samples' => [[
+                [0.5, 10.0, 7.2, -1.0],
+                [-0.5, -10.0, 3.3, -2.0],
+                [1.5, 0.0, -2.4, 4.0],
             ]],
         ];
     }
@@ -354,21 +356,20 @@ class BatchNormTest extends TestCase
         self::assertEqualsWithDelta($expected, $gradient->toArray(), 1e-7);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
+    #[TestDox('Normalizes forward, back, and infer passes with non-square input (3 features x 4 samples)')]
     public function normalizesOverBatchSize() : void
     {
         $fanIn = 3;
 
-        $input = Matrix::quick([
+        $input = NumPower::array([
             [1.0, 2.5, -0.1, 0.5],
             [0.1, 0.0, 3.0, -1.0],
             [0.002, -6.0, -0.5, 2.0],
         ]);
 
-        $prevGrad = new Deferred(function () {
-            return Matrix::quick([
+        $prevGrad = new Deferred(function () : NDArray {
+            return NumPower::array([
                 [0.25, 0.7, 0.1, 0.3],
                 [0.50, 0.2, 0.01, -0.4],
                 [0.25, 0.1, 0.89, 0.6],
@@ -377,42 +378,31 @@ class BatchNormTest extends TestCase
 
         $optimizer = new Stochastic(0.001);
 
-        $layer = new BatchNorm(0.9, new Constant(0.), new Constant(1.));
+        $layer = new BatchNorm(0.9, new Constant(0.0), new Constant(1.0));
 
         $layer->initialize($fanIn);
 
-        $expected = [
-            [0.025967457200229, 1.584014889214, -1.1166006596098, -0.49338168680435],
-            [-0.28480067232747, -0.35181259522806, 1.6585450917894, -1.0219318242339],
-            [0.3797862163235, -1.643717441354, 0.21054282476168, 1.0533884002688],
-        ];
-
         $forward = $layer->forward($input);
 
-        $this->assertInstanceOf(Matrix::class, $forward);
-        $this->assertEqualsWithDelta($expected, $forward->asArray(), 1e-8);
-
-        $expected = [
-            [-0.096655673462753, 0.024584160424222, 0.0014008068617791, 0.070670706176752],
-            [0.29326885034768, 0.094619781903042, -0.10430387932137, -0.28358475292935],
-            [-0.094806324008858, -0.017466016738221, 0.13166046771019, -0.019388126963108],
-        ];
+        self::assertInstanceOf(NDArray::class, $forward);
+        self::assertEquals($input->shape(), $forward->shape());
+        self::assertRowwiseStats($input->toArray(), $forward->toArray(), true);
 
         $gradient = $layer->back($prevGrad, $optimizer)->compute();
 
-        $this->assertInstanceOf(Matrix::class, $gradient);
-        $this->assertEqualsWithDelta($expected, $gradient->asArray(), 1e-8);
+        self::assertInstanceOf(NDArray::class, $gradient);
+        self::assertEquals($input->shape(), $gradient->shape());
 
-        $expected = [
-            [0.024595238724167, 1.5813095621742, -1.1169952651392, -0.49430953575917],
-            [-0.28505012503587, -0.35204780151489, 1.6578824928559, -1.0220245663052],
-            [0.37766138009295, -1.6443246681253, 0.20854491954554, 1.0507583684868],
-        ];
+        $inferLayer = new BatchNorm(0.9, new Constant(0.0), new Constant(1.0));
 
-        $infer = $layer->infer($input);
+        $inferLayer->initialize($fanIn);
+        $inferLayer->forward($input);
 
-        $this->assertInstanceOf(Matrix::class, $infer);
-        $this->assertEqualsWithDelta($expected, $infer->asArray(), 1e-8);
+        $infer = $inferLayer->infer($input);
+
+        self::assertInstanceOf(NDArray::class, $infer);
+        self::assertEquals($input->shape(), $infer->shape());
+        self::assertRowwiseStats($input->toArray(), $infer->toArray(), false);
     }
 
     /**


### PR DESCRIPTION
gamma and beta (1-D [n]) were passed directly to NumPower::multiply with 2-D [n, m] arrays. NumPower broadcasts [n] as [1, n] (NumPy convention), causing:

- Crash when n ≠ m — incompatible broadcast shapes
- Wrong results even when n == m — gamma scaled columns (samples) instead of rows (features), masked by Constant(1.0) tests

| Method | Line | Change |
| -- | -- | -- |
| forward() | 234-237 | Reshape gamma/beta from [n] to [n, 1] before multiply/add |
| infer() | 264-270 | Same reshape pattern |
| gradient() | 327-330 | Reshape gamma from [n] to [n, 1] (moved shape() extraction earlier) |