### PR TITLE
Optimize true negative counting

### DIFF
--- a/src/CrossValidation/Metrics/Informedness.php
+++ b/src/CrossValidation/Metrics/Informedness.php
@@ -83,29 +83,25 @@ class Informedness implements Metric
 
         $classes = array_unique(array_merge($predictions, $labels));
 
-        $truePos = $trueNeg = $falsePos = $falseNeg = array_fill_keys($classes, 0);
+        $n = count($predictions);
+
+        $truePos = $falsePos = $falseNeg = array_fill_keys($classes, 0);
 
         foreach ($predictions as $i => $prediction) {
             $label = $labels[$i];
 
             if ($prediction == $label) {
                 ++$truePos[$prediction];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction) {
-                        ++$trueNeg[$class];
-                    }
-                }
             } else {
                 ++$falsePos[$prediction];
                 ++$falseNeg[$label];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction and $class != $label) {
-                        ++$trueNeg[$class];
-                    }
-                }
             }
+        }
+
+        $trueNeg = [];
+
+        foreach ($classes as $class) {
+            $trueNeg[$class] = $n - $truePos[$class] - $falsePos[$class] - $falseNeg[$class];
         }
 
         $scores = array_map([self::class, 'compute'], $truePos, $trueNeg, $falsePos, $falseNeg);

--- a/src/CrossValidation/Metrics/MCC.php
+++ b/src/CrossValidation/Metrics/MCC.php
@@ -88,29 +88,25 @@ class MCC implements Metric
 
         $classes = array_unique(array_merge($predictions, $labels));
 
-        $truePos = $trueNeg = $falsePos = $falseNeg = array_fill_keys($classes, 0);
+        $n = count($predictions);
+
+        $truePos = $falsePos = $falseNeg = array_fill_keys($classes, 0);
 
         foreach ($predictions as $i => $prediction) {
             $label = $labels[$i];
 
             if ($prediction == $label) {
                 ++$truePos[$prediction];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction) {
-                        ++$trueNeg[$class];
-                    }
-                }
             } else {
                 ++$falsePos[$prediction];
                 ++$falseNeg[$label];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction and $class != $label) {
-                        ++$trueNeg[$class];
-                    }
-                }
             }
+        }
+
+        $trueNeg = [];
+
+        foreach ($classes as $class) {
+            $trueNeg[$class] = $n - $truePos[$class] - $falsePos[$class] - $falseNeg[$class];
         }
 
         $scores = array_map([self::class, 'compute'], $truePos, $trueNeg, $falsePos, $falseNeg);

--- a/src/CrossValidation/Reports/MulticlassBreakdown.php
+++ b/src/CrossValidation/Reports/MulticlassBreakdown.php
@@ -58,29 +58,23 @@ class MulticlassBreakdown implements ReportGenerator
         $n = count($predictions);
         $k = count($classes);
 
-        $truePos = $trueNeg = $falsePos = $falseNeg = array_fill_keys($classes, 0);
+        $truePos = $falsePos = $falseNeg = array_fill_keys($classes, 0);
 
         foreach ($predictions as $i => $prediction) {
             $label = $labels[$i];
 
             if ($prediction == $label) {
                 ++$truePos[$prediction];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction) {
-                        ++$trueNeg[$class];
-                    }
-                }
             } else {
                 ++$falsePos[$prediction];
                 ++$falseNeg[$label];
-
-                foreach ($classes as $class) {
-                    if ($class != $prediction and $class != $label) {
-                        ++$trueNeg[$class];
-                    }
-                }
             }
+        }
+
+        $trueNeg = [];
+
+        foreach ($classes as $class) {
+            $trueNeg[$class] = $n - $truePos[$class] - $falsePos[$class] - $falseNeg[$class];
         }
 
         $averages = array_fill_keys([


### PR DESCRIPTION
MCC.php:93-114, Informedness.php:88-109, MulticlassBreakdown.php:63-84

O(n·k) loops — per prediction, loop over all classes incrementing true-negatives

Closed form: tn[c] = n − tp[c] − fp[c] − fn[c] after one O(n) pass, much faster