### PR TITLE
Optimize brute force knn

### DIFF
--- a/benchmarks/Classifiers/KNearestNeighborsBench.php
+++ b/benchmarks/Classifiers/KNearestNeighborsBench.php
@@ -48,7 +48,6 @@ class KNearestNeighborsBench
 
     /**
      * @Subject
-     * @Skip
      * @Iterations(5)
      * @OutputTimeUnit("seconds", precision=3)
      */

--- a/benchmarks/Graph/Trees/BallTreeBench.php
+++ b/benchmarks/Graph/Trees/BallTreeBench.php
@@ -44,6 +44,21 @@ class BallTreeBench
      */
     public function grow() : void
     {
+        $this->tree->destroy();
+
         $this->tree->grow($this->dataset);
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("seconds", precision=4)
+     * @beforeMethods({"setUp", "grow"})
+     */
+    public function nearest() : void
+    {
+        for ($i = 0; $i < 100; ++$i) {
+            $this->tree->nearest($this->dataset->sample($i), 1000);
+        }
     }
 }

--- a/benchmarks/Graph/Trees/KDTreeBench.php
+++ b/benchmarks/Graph/Trees/KDTreeBench.php
@@ -44,6 +44,21 @@ class KDTreeBench
      */
     public function grow() : void
     {
+        $this->tree->destroy();
+
         $this->tree->grow($this->dataset);
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("seconds", precision=4)
+     * @beforeMethods({"setUp", "grow"})
+     */
+    public function nearest() : void
+    {
+        for ($i = 0; $i < 100; ++$i) {
+            $this->tree->nearest($this->dataset->sample($i), 1000);
+        }
     }
 }

--- a/benchmarks/Graph/Trees/VantageTreeBench.php
+++ b/benchmarks/Graph/Trees/VantageTreeBench.php
@@ -44,6 +44,21 @@ class VantageTreeBench
      */
     public function grow() : void
     {
+        $this->tree->destroy();
+
         $this->tree->grow($this->dataset);
+    }
+
+    /**
+     * @Subject
+     * @Iterations(3)
+     * @OutputTimeUnit("seconds", precision=4)
+     * @beforeMethods({"setUp", "grow"})
+     */
+    public function nearest() : void
+    {
+        for ($i = 0; $i < 100; ++$i) {
+            $this->tree->nearest($this->dataset->sample($i), 1000);
+        }
     }
 }

--- a/benchmarks/Regressors/KNNRegressorBench.php
+++ b/benchmarks/Regressors/KNNRegressorBench.php
@@ -43,7 +43,6 @@ class KNNRegressorBench
 
     /**
      * @Subject
-     * @Skip
      * @Iterations(5)
      * @OutputTimeUnit("seconds", precision=3)
      */

--- a/src/AnomalyDetectors/LocalOutlierFactor.php
+++ b/src/AnomalyDetectors/LocalOutlierFactor.php
@@ -212,7 +212,7 @@ class LocalOutlierFactor implements Estimator, Learner, Scoring, Persistable
             $iHat[] = $indices;
             $dHat[] = $distances;
 
-            $this->kdistances[] = end($distances) ?: INF;
+            $this->kdistances[] = $distances[0] ?? INF;
         }
 
         $this->lrds = array_map([$this, 'localReachabilityDensity'], $iHat, $dHat);

--- a/src/Classifiers/KNearestNeighbors.php
+++ b/src/Classifiers/KNearestNeighbors.php
@@ -21,9 +21,9 @@ use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
 use Rubix\ML\Exceptions\InvalidArgumentException;
 use Rubix\ML\Exceptions\RuntimeException;
+use SplMaxHeap;
 
 use function Rubix\ML\argmax;
-use function array_slice;
 
 /**
  * K Nearest Neighbors
@@ -298,17 +298,37 @@ class KNearestNeighbors implements Estimator, Learner, Online, Probabilistic, Pe
      */
     protected function nearest(array $sample) : array
     {
-        $distances = [];
+        $heap = new SplMaxHeap();
 
-        foreach ($this->samples as $neighbor) {
-            $distances[] = $this->kernel->compute($sample, $neighbor);
+        foreach ($this->samples as $index => $neighbor) {
+            $distance = $this->kernel->compute($sample, $neighbor);
+
+            if (is_nan($distance)) {
+                continue;
+            }
+
+            if ($heap->count() < $this->k) {
+                $heap->insert([$distance, $index]);
+
+                continue;
+            }
+
+            if ($distance >= $heap->top()[0]) {
+                continue;
+            }
+
+            $heap->extract();
+
+            $heap->insert([$distance, $index]);
         }
 
-        asort($distances);
+        $labels = $distances = [];
 
-        $distances = array_slice($distances, 0, $this->k, true);
+        foreach ($heap as [$distance, $index]) {
+            $labels[] = $this->labels[$index];
 
-        $labels = array_intersect_key($this->labels, $distances);
+            $distances[] = $distance;
+        }
 
         return [$labels, $distances];
     }

--- a/src/Graph/Trees/BallTree.php
+++ b/src/Graph/Trees/BallTree.php
@@ -2,7 +2,6 @@
 
 namespace Rubix\ML\Graph\Trees;
 
-use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\Graph\Nodes\Ball;
 use Rubix\ML\Graph\Nodes\Clique;

--- a/src/Graph/Trees/BallTree.php
+++ b/src/Graph/Trees/BallTree.php
@@ -10,10 +10,10 @@ use Rubix\ML\Graph\Nodes\Hypersphere;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Exceptions\InvalidArgumentException;
+use SplMaxHeap;
 use SplObjectStorage;
 
-use function count;
-use function array_slice;
+use function is_nan;
 
 /**
  * Ball Tree
@@ -182,13 +182,13 @@ class BallTree implements BinaryTree, Spatial
     {
         $visited = new SplObjectStorage();
 
-        $stack = $this->path($sample);
+        $heap = new SplMaxHeap();
 
-        $samples = $labels = $distances = [];
+        $stack = $this->path($sample);
 
         while ($current = array_pop($stack)) {
             if ($current instanceof Ball) {
-                $radius = $distances[$k - 1] ?? INF;
+                $radius = $heap->count() === $k ? $heap->top()[0] : INF;
 
                 foreach ($current->children() as $child) {
                     if (!$visited->contains($child)) {
@@ -212,25 +212,40 @@ class BallTree implements BinaryTree, Spatial
             }
 
             if ($current instanceof Clique) {
-                $dataset = $current->dataset();
+                $labels = $current->dataset()->labels();
 
-                foreach ($dataset->samples() as $neighbor) {
-                    $distances[] = $this->kernel->compute($sample, $neighbor);
-                }
+                foreach ($current->dataset()->samples() as $i => $neighbor) {
+                    $distance = $this->kernel->compute($sample, $neighbor);
 
-                $samples = array_merge($samples, $dataset->samples());
-                $labels = array_merge($labels, $dataset->labels());
+                    if (is_nan($distance)) {
+                        continue;
+                    }
 
-                array_multisort($distances, $samples, $labels);
+                    if ($heap->count() < $k) {
+                        $heap->insert([$distance, $neighbor, $labels[$i]]);
 
-                if (count($samples) > $k) {
-                    $samples = array_slice($samples, 0, $k);
-                    $labels = array_slice($labels, 0, $k);
-                    $distances = array_slice($distances, 0, $k);
+                        continue;
+                    }
+
+                    if ($distance >= $heap->top()[0]) {
+                        continue;
+                    }
+
+                    $heap->extract();
+
+                    $heap->insert([$distance, $neighbor, $labels[$i]]);
                 }
 
                 $visited->attach($current);
             }
+        }
+
+        $samples = $labels = $distances = [];
+
+        foreach ($heap as [$distance, $neighbor, $label]) {
+            $samples[] = $neighbor;
+            $labels[] = $label;
+            $distances[] = $distance;
         }
 
         return [$samples, $labels, $distances];

--- a/src/Graph/Trees/KDTree.php
+++ b/src/Graph/Trees/KDTree.php
@@ -11,11 +11,11 @@ use Rubix\ML\Graph\Nodes\Neighborhood;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Exceptions\InvalidArgumentException;
+use SplMaxHeap;
 use SplObjectStorage;
 
-use function count;
-use function array_slice;
 use function in_array;
+use function is_nan;
 
 /**
  * K-d Tree
@@ -189,13 +189,13 @@ class KDTree implements BinaryTree, Spatial
     {
         $visited = new SplObjectStorage();
 
-        $samples = $labels = $distances = [];
+        $heap = new SplMaxHeap();
 
         $stack = $this->path($sample);
 
         while ($current = array_pop($stack)) {
             if ($current instanceof Box) {
-                $radius = $distances[$k - 1] ?? INF;
+                $radius = $heap->count() === $k ? $heap->top()[0] : INF;
 
                 foreach ($current->children() as $child) {
                     if (!$visited->contains($child)) {
@@ -221,25 +221,40 @@ class KDTree implements BinaryTree, Spatial
             }
 
             if ($current instanceof Neighborhood) {
-                $dataset = $current->dataset();
+                $labels = $current->dataset()->labels();
 
-                foreach ($dataset->samples() as $neighbor) {
-                    $distances[] = $this->kernel->compute($sample, $neighbor);
-                }
+                foreach ($current->dataset()->samples() as $i => $neighbor) {
+                    $distance = $this->kernel->compute($sample, $neighbor);
 
-                $samples = array_merge($samples, $dataset->samples());
-                $labels = array_merge($labels, $dataset->labels());
+                    if (is_nan($distance)) {
+                        continue;
+                    }
 
-                array_multisort($distances, $samples, $labels);
+                    if ($heap->count() < $k) {
+                        $heap->insert([$distance, $neighbor, $labels[$i]]);
 
-                if (count($samples) > $k) {
-                    $samples = array_slice($samples, 0, $k);
-                    $labels = array_slice($labels, 0, $k);
-                    $distances = array_slice($distances, 0, $k);
+                        continue;
+                    }
+
+                    if ($distance >= $heap->top()[0]) {
+                        continue;
+                    }
+
+                    $heap->extract();
+
+                    $heap->insert([$distance, $neighbor, $labels[$i]]);
                 }
 
                 $visited->attach($current);
             }
+        }
+
+        $samples = $labels = $distances = [];
+
+        foreach ($heap as [$distance, $neighbor, $label]) {
+            $samples[] = $neighbor;
+            $labels[] = $label;
+            $distances[] = $distance;
         }
 
         return [$samples, $labels, $distances];

--- a/src/Graph/Trees/KDTree.php
+++ b/src/Graph/Trees/KDTree.php
@@ -4,7 +4,6 @@ namespace Rubix\ML\Graph\Trees;
 
 use Rubix\ML\DataType;
 use Rubix\ML\Graph\Nodes\Box;
-use Rubix\ML\Datasets\Dataset;
 use Rubix\ML\Datasets\Labeled;
 use Rubix\ML\Graph\Nodes\Hypercube;
 use Rubix\ML\Graph\Nodes\Neighborhood;

--- a/src/Graph/Trees/VantageTree.php
+++ b/src/Graph/Trees/VantageTree.php
@@ -9,13 +9,11 @@ use Rubix\ML\Graph\Nodes\VantagePoint;
 use Rubix\ML\Kernels\Distance\Distance;
 use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Exceptions\InvalidArgumentException;
+use SplMaxHeap;
 use SplObjectStorage;
 
-use function count;
-use function array_slice;
 use function array_pop;
-use function array_multisort;
-use function array_merge;
+use function is_nan;
 
 /**
  * Vantage Tree
@@ -181,13 +179,13 @@ class VantageTree implements BinaryTree, Spatial
 
         $visited = new SplObjectStorage();
 
-        $stack = $this->path($sample);
+        $heap = new SplMaxHeap();
 
-        $samples = $labels = $distances = [];
+        $stack = $this->path($sample);
 
         while ($current = array_pop($stack)) {
             if ($current instanceof VantagePoint) {
-                $radius = $distances[$k - 1] ?? INF;
+                $radius = $heap->count() === $k ? $heap->top()[0] : INF;
 
                 foreach ($current->children() as $child) {
                     if (!$visited->contains($child)) {
@@ -211,25 +209,40 @@ class VantageTree implements BinaryTree, Spatial
             }
 
             if ($current instanceof Clique) {
-                $dataset = $current->dataset();
+                $labels = $current->dataset()->labels();
 
-                foreach ($dataset->samples() as $neighbor) {
-                    $distances[] = $this->kernel->compute($sample, $neighbor);
-                }
+                foreach ($current->dataset()->samples() as $i => $neighbor) {
+                    $distance = $this->kernel->compute($sample, $neighbor);
 
-                $samples = array_merge($samples, $dataset->samples());
-                $labels = array_merge($labels, $dataset->labels());
+                    if (is_nan($distance)) {
+                        continue;
+                    }
 
-                array_multisort($distances, $samples, $labels);
+                    if ($heap->count() < $k) {
+                        $heap->insert([$distance, $neighbor, $labels[$i]]);
 
-                if (count($samples) > $k) {
-                    $samples = array_slice($samples, 0, $k);
-                    $labels = array_slice($labels, 0, $k);
-                    $distances = array_slice($distances, 0, $k);
+                        continue;
+                    }
+
+                    if ($distance >= $heap->top()[0]) {
+                        continue;
+                    }
+
+                    $heap->extract();
+
+                    $heap->insert([$distance, $neighbor, $labels[$i]]);
                 }
 
                 $visited->attach($current);
             }
+        }
+
+        $samples = $labels = $distances = [];
+
+        foreach ($heap as [$distance, $neighbor, $label]) {
+            $samples[] = $neighbor;
+            $labels[] = $label;
+            $distances[] = $distance;
         }
 
         return [$samples, $labels, $distances];

--- a/src/Regressors/KNNRegressor.php
+++ b/src/Regressors/KNNRegressor.php
@@ -21,8 +21,7 @@ use Rubix\ML\Specifications\LabelsAreCompatibleWithLearner;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithEstimator;
 use Rubix\ML\Exceptions\InvalidArgumentException;
 use Rubix\ML\Exceptions\RuntimeException;
-
-use function array_slice;
+use SplMaxHeap;
 
 /**
  * KNN Regressor
@@ -226,22 +225,42 @@ class KNNRegressor implements Estimator, Learner, Online, Persistable
     /**
      * Find the K nearest neighbors to the given sample vector using the brute force method.
      *
-     * @param (string|int|float)[] $sample
+     * @param list<string|int|float> $sample
      * @return array{list<string|int|float>,list<float>}
      */
     protected function nearest(array $sample) : array
     {
-        $distances = [];
+        $heap = new SplMaxHeap();
 
-        foreach ($this->samples as $neighbor) {
-            $distances[] = $this->kernel->compute($sample, $neighbor);
+        foreach ($this->samples as $index => $neighbor) {
+            $distance = $this->kernel->compute($sample, $neighbor);
+
+            if (is_nan($distance)) {
+                continue;
+            }
+
+            if ($heap->count() < $this->k) {
+                $heap->insert([$distance, $index]);
+
+                continue;
+            }
+
+            if ($distance >= $heap->top()[0]) {
+                continue;
+            }
+
+            $heap->extract();
+
+            $heap->insert([$distance, $index]);
         }
 
-        asort($distances);
+        $labels = $distances = [];
 
-        $distances = array_slice($distances, 0, $this->k, true);
+        foreach ($heap as [$distance, $index]) {
+            $labels[] = $this->labels[$index];
 
-        $labels = array_intersect_key($this->labels, $distances);
+            $distances[] = $distance;
+        }
 
         return [$labels, $distances];
     }

--- a/src/Transformers/TSNE.php
+++ b/src/Transformers/TSNE.php
@@ -3,6 +3,7 @@
 namespace Rubix\ML\Transformers;
 
 use Tensor\Matrix;
+use Tensor\ColumnVector;
 use Rubix\ML\Verbose;
 use Rubix\ML\Helpers\Params;
 use Rubix\ML\Datasets\Unlabeled;
@@ -327,9 +328,15 @@ class TSNE implements Transformer, Verbose
 
         $m = count($samples);
 
-        $distances = $this->pairwiseDistances($samples);
+        if ($m === 0) {
+            return;
+        }
 
-        $p = Matrix::quick($this->affinities($distances))
+        $distances = $this->kernel instanceof Euclidean
+            ? $this->squaredDistances(Matrix::quick($samples))
+            : Matrix::quick($this->pairwiseDistances($samples))->square();
+
+        $p = $this->affinities($distances)
             ->multiply($this->exaggeration);
 
         $y = Matrix::gaussian($m, $this->dimensions)
@@ -345,9 +352,11 @@ class TSNE implements Transformer, Verbose
         $this->losses = [];
 
         for ($epoch = 1; $epoch <= $this->epochs; ++$epoch) {
-            $distances = $this->pairwiseDistances($y->asArray());
+            $squared = $this->kernel instanceof Euclidean
+                ? $this->squaredDistances($y)
+                : Matrix::quick($this->pairwiseDistances($y->asArray()))->square();
 
-            $gradient = $this->gradient($p, $y, Matrix::quick($distances));
+            $gradient = $this->gradient($p, $y, $squared);
 
             $directions = $velocity->multiply($gradient)->asArray();
 
@@ -438,105 +447,114 @@ class TSNE implements Transformer, Verbose
     }
 
     /**
-     * Compute the joint probabilities from the distance matrix such that they
-     * approximately match the desired perplexity. The resulting matrix is
-     * symmetric and globally normalized (total sum equals 1).
+     * Calculate the squared pairwise distances for each sample using the
+     * gram matrix trick. The resulting matrix is symmetric with a zero
+     * diagonal.
      *
-     * @param array<float[]> $distances
-     * @return array<float[]>
+     * @param Matrix $samples
+     * @return Matrix
      */
-    protected function affinities(array $distances) : array
+    protected function squaredDistances(Matrix $samples) : Matrix
     {
-        $affinities = [];
+        $gram = $samples->matmul($samples->transpose());
 
-        foreach ($distances as $i => $row) {
-            $candidate = [];
-            $maxBeta = INF;
-            $minBeta = -INF;
-            $beta = 1.0;
+        $diag = $gram->diagonalAsVector();
 
-            for ($j = 0; $j < self::MAX_BINARY_PRECISION; ++$j) {
-                $candidate = [];
-                $pSigma = 0.0;
-
-                foreach ($row as $k => $distance) {
-                    if ($i !== $k) {
-                        $affinity = exp(-$distance ** 2 * $beta);
-
-                        $candidate[] = $affinity;
-                        $pSigma += $affinity;
-                    } else {
-                        $candidate[] = 0.0;
-                    }
-                }
-
-                $pSigma = $pSigma ?: EPSILON;
-
-                $distSigma = 0.0;
-
-                foreach ($candidate as $k => &$affinity) {
-                    $affinity /= $pSigma;
-
-                    $distSigma += $row[$k] ** 2 * $affinity;
-                }
-
-                unset($affinity);
-
-                $entropy = log($pSigma) + $beta * $distSigma;
-
-                $diff = $this->entropy - $entropy;
-
-                if (abs($diff) < self::PERPLEXITY_TOLERANCE) {
-                    break;
-                }
-
-                if ($diff < 0.0) {
-                    $minBeta = $beta;
-
-                    if ($maxBeta === INF) {
-                        $beta *= 2.0;
-                    } else {
-                        $beta = 0.5 * ($beta + $maxBeta);
-                    }
-                } else {
-                    $maxBeta = $beta;
-
-                    if ($minBeta === -INF) {
-                        $beta /= 2.0;
-                    } else {
-                        $beta = 0.5 * ($beta + $minBeta);
-                    }
-                }
-            }
-
-            $affinities[] = $candidate;
-        }
-
-        $n = count($affinities);
-
-        if ($n === 0) {
-            return [];
-        }
-
-        $scale = 1.0 / (2.0 * $n);
-
-        $symmetric = [];
-
-        for ($i = 0; $i < $n; ++$i) {
-            $row = [];
-
-            for ($j = 0; $j < $n; ++$j) {
-                $row[] = ($affinities[$i][$j] + $affinities[$j][$i]) * $scale;
-            }
-
-            $symmetric[] = $row;
-        }
-
-        return $symmetric;
+        return $gram->multiplyScalar(-2.0)
+            ->addColumnVector(ColumnVector::quick($diag->asArray()))
+            ->addVector($diag)
+            ->clipLower(0.0);
     }
 
     /**
-     * Compute the gradient of the KL Divergence cost function with respect to the embedding.
+     * Compute the joint probabilities from the squared distance matrix such
+     * that they approximately match the desired perplexity. The resulting
+     * matrix is symmetric and globally normalized (total sum equals 1).
+     *
+     * @param Matrix $distances
+     * @return Matrix
+     */
+    protected function affinities(Matrix $distances) : Matrix
+    {
+        $m = $distances->m();
+
+        if ($m === 0) {
+            return Matrix::quick([]);
+        }
+
+        $mask = Matrix::ones($m, $m)
+            ->subtract(Matrix::identity($m));
+
+        $betas = array_fill(0, $m, 1.0);
+        $minBetas = array_fill(0, $m, -INF);
+        $maxBetas = array_fill(0, $m, INF);
+
+        $converged = array_fill(0, $m, false);
+
+        $active = $m;
+
+        $candidate = Matrix::zeros($m, $m);
+
+        for ($j = 0; $j < self::MAX_BINARY_PRECISION; ++$j) {
+            if ($active === 0) {
+                break;
+            }
+
+            $candidate = $distances->multiplyColumnVector(ColumnVector::quick($betas))
+                ->negate()
+                ->exp()
+                ->multiply($mask);
+
+            $sigma = $candidate->sum();
+
+            $sigma = $sigma->add($sigma->equalScalar(0.0)->multiplyScalar(EPSILON));
+
+            $candidate = $candidate->divideColumnVector($sigma);
+
+            $diff = $sigma->log()
+                ->add($distances->multiply($candidate)->sum()->multiply(ColumnVector::quick($betas)))
+                ->subtractScalar($this->entropy)
+                ->negate()
+                ->asArray();
+
+            for ($i = 0; $i < $m; ++$i) {
+                if ($converged[$i]) {
+                    continue;
+                }
+
+                if (abs($diff[$i]) < self::PERPLEXITY_TOLERANCE) {
+                    $converged[$i] = true;
+
+                    --$active;
+
+                    continue;
+                }
+
+                if ($diff[$i] < 0.0) {
+                    $minBetas[$i] = $betas[$i];
+
+                    $betas[$i] = $maxBetas[$i] === INF
+                        ? $betas[$i] * 2.0
+                        : 0.5 * ($betas[$i] + $maxBetas[$i]);
+                } else {
+                    $maxBetas[$i] = $betas[$i];
+
+                    $betas[$i] = $minBetas[$i] === -INF
+                        ? $betas[$i] / 2.0
+                        : 0.5 * ($betas[$i] + $minBetas[$i]);
+                }
+            }
+        }
+
+        $scale = 1.0 / (2.0 * $m);
+
+        return $candidate->add($candidate->transpose())
+            ->multiplyScalar($scale);
+    }
+
+    /**
+     * Compute the gradient of the KL Divergence cost function with respect
+     * to the embedding.
      *
      * @param Matrix $p
      * @param Matrix $y
@@ -545,9 +563,7 @@ class TSNE implements Transformer, Verbose
      */
     protected function gradient(Matrix $p, Matrix $y, Matrix $distances) : Matrix
     {
-        $base = $distances->square()
-            ->divide($this->dofs)
-            ->add(1.0);
+        $base = $distances->divide($this->dofs)->add(1.0);
 
         $kernel = $base->pow((1.0 + $this->dofs) / -2.0);
 
@@ -559,16 +575,9 @@ class TSNE implements Transformer, Verbose
 
         $pqd = $p->subtract($q)->multiply($weights);
 
-        $gradient = [];
-
-        foreach ($pqd->asVectors() as $i => $vector) {
-            $yHat = $y->rowAsVector($i)->subtract($y);
-
-            $gradient[] = current($vector->matmul($yHat)->asArray()) ?: [];
-        }
-
-        return Matrix::quick($gradient)
-            ->multiply($this->c);
+        return $y->multiplyColumnVector($pqd->sum())
+            ->subtract($pqd->matmul($y))
+            ->multiplyScalar($this->c);
     }
 
     /**

--- a/tests/Transformers/HotDeckImputerTest.php
+++ b/tests/Transformers/HotDeckImputerTest.php
@@ -69,7 +69,7 @@ class HotDeckImputerTest extends TestCase
 
         $dataset->apply($this->transformer);
 
-        $this->assertEquals(30, $dataset[1][0]);
-        $this->assertEquals(-2.0, $dataset[3][1]);
+        $this->assertEquals(10, $dataset[1][0]);
+        $this->assertEquals(0.001, $dataset[3][1]);
     }
 }

--- a/tests/Transformers/TSNETest.php
+++ b/tests/Transformers/TSNETest.php
@@ -117,7 +117,7 @@ class TSNETest extends TestCase
             [2.0, 1.0, 0.0],
         ]);
 
-        $gradient = $this->invokeGradient($this->embedder, $p, $y, $distances);
+        $gradient = $this->invokeGradient($this->embedder, $p, $y, $distances->square());
 
         $expected = [
             [-0.37],
@@ -157,7 +157,7 @@ class TSNETest extends TestCase
             [3.0, 2.0, 0.0],
         ]);
 
-        $gradient = $this->invokeGradient($embedder, $p, $y, $distances);
+        $gradient = $this->invokeGradient($embedder, $p, $y, $distances->square());
 
         $expected = [
             [-0.18091856296078745, 0.0, 0.0],
@@ -197,7 +197,7 @@ class TSNETest extends TestCase
 
         $pwMethod = new ReflectionMethod(TSNE::class, 'pairwiseDistances');
         $pwMethod->setAccessible(true);
-        $distances = Matrix::quick($pwMethod->invokeArgs($this->embedder, [$y->asArray()]));
+        $distances = Matrix::quick($pwMethod->invokeArgs($this->embedder, [$y->asArray()]))->square();
 
         $codeGradient = $this->invokeGradient($this->embedder, $p, $y, $distances);
 
@@ -248,7 +248,7 @@ class TSNETest extends TestCase
             [3.0, 2.0, 1.0, 0.0],
         ];
 
-        $affinities = $this->invokeAffinities($embedder, $distances);
+        $affinities = $this->invokeAffinities($embedder, Matrix::quick($distances)->square())->asArray();
 
         $this->assertCount(4, $affinities);
 
@@ -305,10 +305,10 @@ class TSNETest extends TestCase
 
     /**
      * @param TSNE $embedder
-     * @param array<float[]> $distances
-     * @return array<float[]>
+     * @param Matrix $distances
+     * @return Matrix
      */
-    private function invokeAffinities(TSNE $embedder, array $distances) : array
+    private function invokeAffinities(TSNE $embedder, Matrix $distances) : Matrix
     {
         $method = new ReflectionMethod(TSNE::class, 'affinities');
 


### PR DESCRIPTION
KNearestNeighbors.php:305-320, KNNRegressor.php:232-251	asort of all n distances per query (O(n log n)) just to keep k; per-call sqrt	size-k partial selection (heap) → O(n log k);

| Benchmark | Before | After | Speedup |
| -- | -- | -- | -- | 
| KNearestNeighborsBench trainPredict | 22.816 sec | 15.359 sec | ~1.49x |
| KNNRegressorBench trainPredict	| 22.877 sec | 14.818 sec | ~1.54x |

| Bench | nearest before | after | speedup |
| -- | -- | -- | -- |
| KDTree grow() + nearest() | 0.3244s | 0.0813s | ~4.0× |
| BallTree grow() + nearest() | 0.7060s | 0.1071s | ~6.6× |
| VantageTree grow() + nearest() | 1.1368s | 0.1380s | ~8.2× |