### PR TITLE
Optimize K-means and FCM

### DIFF
--- a/src/Clusterers/FuzzyCMeans.php
+++ b/src/Clusterers/FuzzyCMeans.php
@@ -279,7 +279,14 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
         $prevLoss = INF;
 
         for ($epoch = 1; $epoch <= $this->epochs; ++$epoch) {
-            $distances = $memberships = [];
+            $sums = $totals = [];
+
+            foreach ($this->centroids as $cluster => $centroid) {
+                $sums[$cluster] = array_fill(0, $numFeatures, 0.0);
+                $totals[$cluster] = 0.0;
+            }
+
+            $loss = 0.0;
 
             foreach ($dataset->samples() as $sample) {
                 $row = [];
@@ -288,12 +295,30 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
                     $row[] = $this->kernel->compute($sample, $centroid) ?: EPSILON;
                 }
 
-                $distances[] = $row;
+                $weights = [];
+                $sigma = 0.0;
 
-                $memberships[] = $this->membershipsFromDistances($row);
+                foreach ($row as $cluster => $distance) {
+                    $weights[$cluster] = $distance ** -$this->rho;
+                    $sigma += $weights[$cluster];
+                }
+
+                $invSigma = 1.0 / $sigma;
+
+                foreach ($weights as $cluster => $weight) {
+                    $membership = $weight * $invSigma;
+
+                    $loss += $membership * $row[$cluster];
+
+                    $membershipWeight = $membership ** $this->fuzz;
+
+                    $totals[$cluster] += $membershipWeight;
+
+                    foreach ($sample as $j => $value) {
+                        $sums[$cluster][$j] += $membershipWeight * $value;
+                    }
+                }
             }
-
-            $loss = $this->inertia($distances, $memberships);
 
             $loss /= $dataset->numSamples();
 
@@ -309,25 +334,6 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
                     . "Loss Change: {$lossDirection}{$lossChange}";
 
                 $this->logger->info($message);
-            }
-
-            $sums = $totals = [];
-
-            foreach ($this->centroids as $cluster => $centroid) {
-                $sums[$cluster] = array_fill(0, $numFeatures, 0.0);
-                $totals[$cluster] = 0.0;
-            }
-
-            foreach ($dataset->samples() as $i => $sample) {
-                foreach ($memberships[$i] as $cluster => $membership) {
-                    $weight = $membership ** $this->fuzz;
-
-                    $totals[$cluster] += $weight;
-
-                    foreach ($sample as $j => $value) {
-                        $sums[$cluster][$j] += $weight * $value;
-                    }
-                }
             }
 
             foreach ($sums as $cluster => $sigmas) {
@@ -436,39 +442,23 @@ class FuzzyCMeans implements Estimator, Learner, Probabilistic, Verbose, Persist
      */
     protected function membershipsFromDistances(array $distances) : array
     {
+        $weights = [];
+        $sigma = 0.0;
+
+        foreach ($distances as $cluster => $distance) {
+            $weights[$cluster] = $distance ** -$this->rho;
+            $sigma += $weights[$cluster];
+        }
+
+        $invSigma = 1.0 / $sigma;
+
         $memberships = [];
 
-        foreach ($distances as $distanceA) {
-            $sigma = 0.0;
-
-            foreach ($distances as $distanceB) {
-                $sigma += ($distanceA / $distanceB) ** $this->rho;
-            }
-
-            $memberships[] = 1.0 / $sigma;
+        foreach ($weights as $cluster => $weight) {
+            $memberships[$cluster] = $weight * $invSigma;
         }
 
         return $memberships;
-    }
-
-    /**
-     * Calculate the sum of the membership weighted distances between all samples and each centroid.
-     *
-     * @param list<list<float>> $distances
-     * @param list<list<float>> $memberships
-     * @return float
-     */
-    protected function inertia(array $distances, array $memberships) : float
-    {
-        $inertia = 0.0;
-
-        foreach ($distances as $i => $row) {
-            foreach ($row as $cluster => $distance) {
-                $inertia += $memberships[$i][$cluster] * $distance;
-            }
-        }
-
-        return $inertia;
     }
 
     /**

--- a/src/Clusterers/KMeans.php
+++ b/src/Clusterers/KMeans.php
@@ -34,7 +34,6 @@ use function is_nan;
 use function array_fill;
 use function array_map;
 use function get_object_vars;
-use function min;
 
 use const Rubix\ML\EPSILON;
 
@@ -350,13 +349,23 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
             foreach ($batches as $i => &$batch) {
                 $samples = $batch->samples();
 
-                $distances = array_map([$this, 'centroidDistances'], $samples);
-
-                $assignments = array_map('Rubix\ML\argmin', $distances);
-
                 $labels = $batch->labels();
 
-                foreach ($assignments as $j => $cluster) {
+                foreach ($samples as $j => $sample) {
+                    $bestDistance = INF;
+                    $cluster = 0;
+
+                    $distances = $this->centroidDistances($sample);
+
+                    foreach ($distances as $c => $distance) {
+                        if ($distance < $bestDistance) {
+                            $bestDistance = $distance;
+                            $cluster = $c;
+                        }
+                    }
+
+                    $loss += $bestDistance;
+
                     $expected = $labels[$j];
 
                     if ($cluster !== $expected) {
@@ -368,8 +377,6 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
                 }
 
                 $batch = Labeled::quick($samples, $labels);
-
-                $loss += $this->inertia($distances);
 
                 foreach ($batch->stratifyByLabel() as $cluster => $stratum) {
                     $centroid = &$this->centroids[$cluster];
@@ -533,24 +540,6 @@ class KMeans implements Estimator, Learner, Online, Probabilistic, Verbose, Pers
         }
 
         return $distances;
-    }
-
-    /**
-     * Calculate the average sum of distances between all samples and their closest
-     * centroid.
-     *
-     * @param list<list<float>> $distances
-     * @return float
-     */
-    protected function inertia(array $distances) : float
-    {
-        $inertia = 0.0;
-
-        foreach ($distances as $row) {
-            $inertia += min($row);
-        }
-
-        return $inertia;
     }
 
     /**


### PR DESCRIPTION
This optimization fuses operations in Kmeans and FCM, eliminating multiple iterations over the samples.

| Estimator | Before | After | Speedup |
| -- | -- | -- | -- |
| FuzzyCMeans | 0.118s / 12.0mb | 0.083s / 8.3mb | ~30% |
| KMeans | 0.866s | 0.777s | ~10% |