### PR TITLE
Optimize N-gram and K-skip N-gram tokenizers

### DIFF
--- a/benchmarks/Tokenizers/KSkipNGramBench.php
+++ b/benchmarks/Tokenizers/KSkipNGramBench.php
@@ -19,7 +19,7 @@ class KSkipNGramBench
 
     public function setUp() : void
     {
-        $this->tokenizer = new KSkipNGram(2, 3);
+        $this->tokenizer = new KSkipNGram(2, 8);
     }
 
     /**

--- a/benchmarks/Tokenizers/NGramBench.php
+++ b/benchmarks/Tokenizers/NGramBench.php
@@ -19,7 +19,7 @@ class NGramBench
 
     public function setUp() : void
     {
-        $this->tokenizer = new NGram(1, 2);
+        $this->tokenizer = new NGram(1, 8);
     }
 
     /**

--- a/src/Tokenizers/KSkipNGram.php
+++ b/src/Tokenizers/KSkipNGram.php
@@ -113,6 +113,8 @@ class KSkipNGram implements Tokenizer
             $n = count($words);
 
             foreach ($words as $i => $word) {
+                $partialGrams = [];
+
                 for ($j = $this->min; $j <= $this->max; ++$j) {
                     if ($j === 1) {
                         $skipGrams[] = $word;
@@ -123,13 +125,10 @@ class KSkipNGram implements Tokenizer
                     $p = min($n - ($i + $j), $this->skip);
 
                     for ($k = 0; $k <= $p; ++$k) {
-                        $skipGram = $word;
+                        $partialGrams[$k] = ($partialGrams[$k] ?? $word)
+                            . self::SEPARATOR . $words[$i + $k + $j - 1];
 
-                        for ($l = 1; $l < $j; ++$l) {
-                            $skipGram .= self::SEPARATOR . $words[$i + $k + $l];
-                        }
-
-                        $skipGrams[] = $skipGram;
+                        $skipGrams[] = $partialGrams[$k];
                     }
                 }
             }

--- a/src/Tokenizers/KSkipNGram.php
+++ b/src/Tokenizers/KSkipNGram.php
@@ -113,22 +113,22 @@ class KSkipNGram implements Tokenizer
             $n = count($words);
 
             foreach ($words as $i => $word) {
+                if ($this->min === 1) {
+                    $skipGrams[] = $word;
+                }
+
                 $partialGrams = [];
 
-                for ($j = $this->min; $j <= $this->max; ++$j) {
-                    if ($j === 1) {
-                        $skipGrams[] = $word;
-
-                        continue;
-                    }
-
+                for ($j = 2; $j <= $this->max; ++$j) {
                     $p = min($n - ($i + $j), $this->skip);
 
                     for ($k = 0; $k <= $p; ++$k) {
                         $partialGrams[$k] = ($partialGrams[$k] ?? $word)
                             . self::SEPARATOR . $words[$i + $k + $j - 1];
 
-                        $skipGrams[] = $partialGrams[$k];
+                        if ($j >= $this->min) {
+                            $skipGrams[] = $partialGrams[$k];
+                        }
                     }
                 }
             }

--- a/src/Tokenizers/NGram.php
+++ b/src/Tokenizers/NGram.php
@@ -99,11 +99,11 @@ class NGram implements Tokenizer
             foreach ($words as $i => $word) {
                 $p = min($n - $i, $this->max);
 
-                for ($j = $this->min; $j <= $p; ++$j) {
-                    $nGram = $word;
+                $nGram = $word;
 
-                    for ($k = 1; $k < $j; ++$k) {
-                        $nGram .= self::SEPARATOR . $words[$i + $k];
+                for ($j = $this->min; $j <= $p; ++$j) {
+                    if ($j > $this->min) {
+                        $nGram .= self::SEPARATOR . $words[$i + $j - 1];
                     }
 
                     $nGrams[] = $nGram;

--- a/src/Tokenizers/NGram.php
+++ b/src/Tokenizers/NGram.php
@@ -99,14 +99,18 @@ class NGram implements Tokenizer
             foreach ($words as $i => $word) {
                 $p = min($n - $i, $this->max);
 
+                if ($this->min === 1) {
+                    $nGrams[] = $word;
+                }
+
                 $nGram = $word;
 
-                for ($j = $this->min; $j <= $p; ++$j) {
-                    if ($j > $this->min) {
-                        $nGram .= self::SEPARATOR . $words[$i + $j - 1];
-                    }
+                for ($j = 2; $j <= $p; ++$j) {
+                    $nGram .= self::SEPARATOR . $words[$i + $j - 1];
 
-                    $nGrams[] = $nGram;
+                    if ($j >= $this->min) {
+                        $nGrams[] = $nGram;
+                    }
                 }
             }
         }

--- a/tests/Tokenizers/KSkipNGramTest.php
+++ b/tests/Tokenizers/KSkipNGramTest.php
@@ -66,6 +66,22 @@ class KSkipNGramTest extends TestCase
     }
 
     /**
+     * @test
+     * @dataProvider minThreeProvider
+     *
+     * @param string $text
+     * @param list<string> $expected
+     */
+    public function tokenizeMinThree(string $text, array $expected) : void
+    {
+        $tokenizer = new KSkipNGram(3, 4, 1);
+
+        $tokens = $tokenizer->tokenize($text);
+
+        $this->assertEquals($expected, $tokens);
+    }
+
+    /**
      * @return Generator<mixed[]>
      */
     public function tokenizeProvider() : Generator
@@ -102,6 +118,20 @@ class KSkipNGramTest extends TestCase
             [
                 'I', 'would', 'like', 'to', 'die', 'on', 'Mars', 'just', 'not', 'on', 'impact',
                 'The', 'end',
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator<mixed[]>
+     */
+    public function minThreeProvider() : Generator
+    {
+        yield [
+            'a b c d e',
+            [
+                'a b c', 'a c d', 'a b c d', 'a c d e', 'b c d',
+                'b d e', 'b c d e', 'c d e',
             ],
         ];
     }

--- a/tests/Tokenizers/NGramTest.php
+++ b/tests/Tokenizers/NGramTest.php
@@ -50,6 +50,22 @@ class NGramTest extends TestCase
     }
 
     /**
+     * @test
+     * @dataProvider trigramProvider
+     *
+     * @param string $text
+     * @param list<string> $expected
+     */
+    public function tokenizeTrigrams(string $text, array $expected) : void
+    {
+        $tokenizer = new NGram(2, 3);
+
+        $tokens = $tokenizer->tokenize($text);
+
+        $this->assertEquals($expected, $tokens);
+    }
+
+    /**
      * @return Generator<mixed[]>
      */
     public function tokenizeProvider() : Generator
@@ -63,6 +79,20 @@ class NGramTest extends TestCase
                 "I'd", "I'd like", 'like', 'like to', 'to', 'to die', 'die',
                 'die on', 'on', 'on Mars', 'Mars', 'Mars just', 'just', 'just not', 'not', 'not on',
                 'on', 'on impact', 'impact', 'The', 'The end', 'end',
+            ],
+        ];
+    }
+
+    /**
+     * @return Generator<mixed[]>
+     */
+    public function trigramProvider() : Generator
+    {
+        yield [
+            'the quick brown fox jumps',
+            [
+                'the quick', 'the quick brown', 'quick brown', 'quick brown fox',
+                'brown fox', 'brown fox jumps', 'fox jumps',
             ],
         ];
     }


### PR DESCRIPTION
Let's reuse some of the previous n-grams instead of building every one from scratch.

| Benchmark | Before | After | Speedup |
| -- | -- | -- | -- |
| NGram (1,8) | 0.090ms | 0.053ms | ~41% faster |
| KSkipNGram (2,8) | 0.218ms | 0.113ms | ~48% faster |