### PR TITLE
TSNE drop custom distance kernel + optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pyvenv.cfg
 .idea
 .vscode
 .vs
+.phpbench
 Dockerfile
 /runtime/
 /docker/

--- a/benchmarks/Transformers/TSNEBench.php
+++ b/benchmarks/Transformers/TSNEBench.php
@@ -39,7 +39,6 @@ class TSNEBench
 
     /**
      * @Subject
-     * @Skip
      * @Iterations(5)
      * @OutputTimeUnit("seconds", precision=3)
      */

--- a/docs/transformers/t-sne.md
+++ b/docs/transformers/t-sne.md
@@ -8,7 +8,7 @@
 
 **Interfaces:** [Transformer](../transformers/api.md#transformer), [Verbose](../verbose.md)
 
-**Data Type Compatibility:** Depends on distance kernel
+**Data Type Compatibility:** Continuous
 
 ## Parameters
 | # | Name | Default | Type | Description |
@@ -19,14 +19,12 @@
 | 4 | exaggeration | 12.0 | float | The factor to exaggerate the distances between samples during the early stage of embedding. |
 | 5 | epochs | 1000 | int | The maximum number of times to iterate over the embedding. |
 | 6 | minGradient | 1e-7 | float | The minimum norm of the gradient necessary to continue embedding. |
-| 7 | kernel | Euclidean | Distance | The distance kernel to use when measuring distances between samples. |
 
 ## Example
 ```php
 use Rubix\ML\Transformers\TSNE;
-use Rubix\ML\Kernels\Distance\Manhattan;
 
-$transformer = new TSNE(3, 10.0, 30, 12.0, 500, 1e-6, new Manhattan());
+$transformer = new TSNE(3, 10.0, 30, 12.0, 500, 1e-6);
 ```
 
 ## Additional Methods

--- a/src/Transformers/TSNE.php
+++ b/src/Transformers/TSNE.php
@@ -3,7 +3,6 @@
 namespace Rubix\ML\Transformers;
 
 use Tensor\Matrix;
-use Tensor\Vector;
 use Rubix\ML\DataType;
 use Rubix\ML\Verbose;
 use Rubix\ML\Helpers\Params;
@@ -393,7 +392,7 @@ class TSNE implements Transformer, Verbose
 
         return $dots->multiplyScalar(-2.0)
             ->addColumnVector($norms)
-            ->add(Vector::quick($norms->asArray()));
+            ->addVector($norms->transpose());
     }
 
     /**

--- a/src/Transformers/TSNE.php
+++ b/src/Transformers/TSNE.php
@@ -303,7 +303,7 @@ class TSNE implements Transformer, Verbose
 
         $m = count($samples);
 
-        $distances = $this->squaredPairwiseDistances(Matrix::quick($samples));
+        $distances = $this->pairwiseDistances(Matrix::quick($samples));
 
         $p = Matrix::quick($this->affinities($distances))
             ->multiply($this->exaggeration);
@@ -319,7 +319,7 @@ class TSNE implements Transformer, Verbose
         $this->losses = [];
 
         for ($epoch = 1; $epoch <= $this->epochs; ++$epoch) {
-            $distances = $this->squaredPairwiseDistances($y);
+            $distances = $this->pairwiseDistances($y);
 
             $gradient = $this->gradient($p, $y, $distances);
 
@@ -384,7 +384,7 @@ class TSNE implements Transformer, Verbose
      * @param Matrix $samples
      * @return Matrix
      */
-    protected function squaredPairwiseDistances(Matrix $samples) : Matrix
+    protected function pairwiseDistances(Matrix $samples) : Matrix
     {
         $norms = $samples->square()->sum();
 

--- a/src/Transformers/TSNE.php
+++ b/src/Transformers/TSNE.php
@@ -3,12 +3,12 @@
 namespace Rubix\ML\Transformers;
 
 use Tensor\Matrix;
+use Tensor\Vector;
+use Rubix\ML\DataType;
 use Rubix\ML\Verbose;
 use Rubix\ML\Helpers\Params;
 use Rubix\ML\Datasets\Unlabeled;
 use Rubix\ML\Traits\LoggerAware;
-use Rubix\ML\Kernels\Distance\Distance;
-use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
 use Rubix\ML\Exceptions\InvalidArgumentException;
 use Generator;
@@ -179,13 +179,6 @@ class TSNE implements Transformer, Verbose
     protected float $minGradient;
 
     /**
-     * The distance metric used to measure distances between samples in both high and low dimensions.
-     *
-     * @var Distance
-     */
-    protected Distance $kernel;
-
-    /**
      * The loss at each epoch from the last embedding.
      *
      * @var float[]|null
@@ -199,7 +192,6 @@ class TSNE implements Transformer, Verbose
      * @param float $exaggeration
      * @param int $epochs
      * @param float $minGradient
-     * @param Distance|null $kernel
      * @throws InvalidArgumentException
      */
     public function __construct(
@@ -208,8 +200,7 @@ class TSNE implements Transformer, Verbose
         int $perplexity = 30,
         float $exaggeration = 12.0,
         int $epochs = 1000,
-        float $minGradient = 1e-7,
-        ?Distance $kernel = null
+        float $minGradient = 1e-7
     ) {
         if ($dimensions < 1) {
             throw new InvalidArgumentException('Dimensions must be'
@@ -253,7 +244,6 @@ class TSNE implements Transformer, Verbose
         $this->epochs = $epochs;
         $this->early = min(self::MAX_EARLY_EPOCHS, (int) round($epochs / 4));
         $this->minGradient = $minGradient;
-        $this->kernel = $kernel ?? new Euclidean();
     }
 
     /**
@@ -261,11 +251,13 @@ class TSNE implements Transformer, Verbose
      *
      * @internal
      *
-     * @return list<\Rubix\ML\DataType>
+     * @return list<DataType>
      */
     public function compatibility() : array
     {
-        return $this->kernel->compatibility();
+        return [
+            DataType::continuous(),
+        ];
     }
 
     /**
@@ -312,7 +304,7 @@ class TSNE implements Transformer, Verbose
 
         $m = count($samples);
 
-        $distances = $this->pairwiseDistances($samples);
+        $distances = $this->squaredPairwiseDistances(Matrix::quick($samples));
 
         $p = Matrix::quick($this->affinities($distances))
             ->multiply($this->exaggeration);
@@ -328,9 +320,9 @@ class TSNE implements Transformer, Verbose
         $this->losses = [];
 
         for ($epoch = 1; $epoch <= $this->epochs; ++$epoch) {
-            $distances = $this->pairwiseDistances($y->asArray());
+            $distances = $this->squaredPairwiseDistances($y);
 
-            $gradient = $this->gradient($p, $y, Matrix::quick($distances));
+            $gradient = $this->gradient($p, $y, $distances);
 
             $directions = $velocity->multiply($gradient)->asArray();
 
@@ -386,41 +378,39 @@ class TSNE implements Transformer, Verbose
     }
 
     /**
-     * Calculate the pairwise distances for each sample and return them in a 2-d array.
+     * Calculate the squared pairwise distances for each sample using the
+     * ||a - b||^2 = ||a||^2 + ||b||^2 - 2a.b identity and return them as a
+     * matrix.
      *
-     * @param array<mixed[]> $samples
-     * @return array<float[]>
+     * @param Matrix $samples
+     * @return Matrix
      */
-    protected function pairwiseDistances(array $samples) : array
+    protected function squaredPairwiseDistances(Matrix $samples) : Matrix
     {
-        $distances = [];
+        $norms = $samples->square()->sum();
 
-        foreach ($samples as $i => $sampleA) {
-            $row = [];
+        $dots = $samples->matmul($samples->transpose());
 
-            foreach ($samples as $j => $sampleB) {
-                $row[] = $i !== $j ? $this->kernel->compute($sampleA, $sampleB) : 0.0;
-            }
-
-            $distances[] = $row;
-        }
-
-        return $distances;
+        return $dots->multiplyScalar(-2.0)
+            ->addColumnVector($norms)
+            ->add(Vector::quick($norms->asArray()));
     }
 
     /**
-     * Compute the joint probabilities from the distance matrix such that they
-     * approximately match the desired perplexity. The resulting matrix is
-     * symmetric and globally normalized (total sum equals 1).
+     * Compute the joint probabilities from the squared distance matrix such
+     * that they approximately match the desired perplexity. The resulting
+     * matrix is symmetric and globally normalized (total sum equals 1).
      *
-     * @param array<float[]> $distances
+     * @param Matrix $distances
      * @return array<float[]>
      */
-    protected function affinities(array $distances) : array
+    protected function affinities(Matrix $distances) : array
     {
         $affinities = [];
 
-        foreach ($distances as $i => $row) {
+        foreach ($distances->asVectors() as $i => $vector) {
+            $row = $vector->asArray();
+
             $candidate = [];
             $maxBeta = INF;
             $minBeta = -INF;
@@ -432,7 +422,7 @@ class TSNE implements Transformer, Verbose
 
                 foreach ($row as $k => $distance) {
                     if ($i !== $k) {
-                        $affinity = exp(-$distance ** 2 * $beta);
+                        $affinity = exp(-$distance * $beta);
 
                         $candidate[] = $affinity;
                         $pSigma += $affinity;
@@ -448,7 +438,7 @@ class TSNE implements Transformer, Verbose
                 foreach ($candidate as $k => &$affinity) {
                     $affinity /= $pSigma;
 
-                    $distSigma += $row[$k] ** 2 * $affinity;
+                    $distSigma += $row[$k] * $affinity;
                 }
 
                 unset($affinity);
@@ -507,7 +497,8 @@ class TSNE implements Transformer, Verbose
     }
 
     /**
-     * Compute the gradient of the KL Divergence cost function with respect to the embedding.
+     * Compute the gradient of the KL Divergence cost function with respect to
+     * the embedding.
      *
      * @param Matrix $p
      * @param Matrix $y
@@ -516,13 +507,15 @@ class TSNE implements Transformer, Verbose
      */
     protected function gradient(Matrix $p, Matrix $y, Matrix $distances) : Matrix
     {
-        $base = $distances->square()
-            ->divide($this->dofs)
-            ->add(1.0);
+        $base = $this->dofs === 1
+            ? $distances->add(1.0)
+            : $distances->divide($this->dofs)->add(1.0);
 
-        $kernel = $base->pow((1.0 + $this->dofs) / -2.0);
+        $weights = $base->reciprocal();
 
-        $weights = $base->pow(-1.0);
+        $kernel = $this->dofs === 1
+            ? $weights
+            : $weights->pow((1.0 + $this->dofs) * 0.5);
 
         $norm = $kernel->sum()->sum() - $kernel->diagonalAsVector()->sum();
 
@@ -530,15 +523,10 @@ class TSNE implements Transformer, Verbose
 
         $pqd = $p->subtract($q)->multiply($weights);
 
-        $gradient = [];
+        $rowSums = $pqd->sum();
 
-        foreach ($pqd->asVectors() as $i => $vector) {
-            $yHat = $y->rowAsVector($i)->subtract($y);
-
-            $gradient[] = current($vector->matmul($yHat)->asArray()) ?: [];
-        }
-
-        return Matrix::quick($gradient)
+        return $y->multiplyColumnVector($rowSums)
+            ->subtract($pqd->matmul($y))
             ->multiply($this->c);
     }
 
@@ -574,7 +562,6 @@ class TSNE implements Transformer, Verbose
             'exaggeration' => $this->exaggeration,
             'epochs' => $this->epochs,
             'min gradient' => $this->minGradient,
-            'kernel' => $this->kernel,
         ]) . ')';
     }
 }

--- a/tests/Transformers/TSNETest.php
+++ b/tests/Transformers/TSNETest.php
@@ -11,7 +11,6 @@ use ReflectionProperty;
 use Rubix\ML\DataType;
 use Rubix\ML\Loggers\BlackHole;
 use Rubix\ML\Transformers\TSNE;
-use Rubix\ML\Kernels\Distance\Euclidean;
 use Rubix\ML\Datasets\Generators\Blob;
 use Rubix\ML\Datasets\Generators\Agglomerate;
 use Rubix\ML\Exceptions\InvalidArgumentException;
@@ -53,8 +52,7 @@ class TSNETest extends TestCase
             perplexity: 10,
             exaggeration: 12.0,
             epochs: 500,
-            minGradient: 1e-7,
-            kernel: new Euclidean()
+            minGradient: 0.0
         );
 
         $this->embedder->setLogger(new BlackHole());
@@ -110,7 +108,7 @@ class TSNETest extends TestCase
 
         $this->assertEquals(
             't-SNE (dimensions: 2, rate: 100, perplexity: 30, exaggeration: 12, epochs: 1000, '
-            . 'min gradient: 1.0E-7, kernel: Euclidean)',
+            . 'min gradient: 1.0E-7)',
             (string) $tsne
         );
     }
@@ -142,9 +140,9 @@ class TSNETest extends TestCase
         ]);
 
         $distances = Matrix::quick([
-            [0.0, 1.0, 2.0],
+            [0.0, 1.0, 4.0],
             [1.0, 0.0, 1.0],
-            [2.0, 1.0, 0.0],
+            [4.0, 1.0, 0.0],
         ]);
 
         $gradient = $this->invokeGradient($this->embedder, $p, $y, $distances);
@@ -167,7 +165,14 @@ class TSNETest extends TestCase
      */
     public function gradientWeight() : void
     {
-        $embedder = new TSNE(3, 10.0, 10, 12.0, 500, 1e-7, 10, new Euclidean());
+        $embedder = new TSNE(
+            dimensions: 3,
+            rate: 10.0,
+            perplexity: 10,
+            exaggeration: 12.0,
+            epochs: 500,
+            minGradient: 1e-7
+        );
 
         $p = Matrix::quick([
             [0.0, 0.3, 0.2],
@@ -182,9 +187,9 @@ class TSNETest extends TestCase
         ]);
 
         $distances = Matrix::quick([
-            [0.0, 1.0, 3.0],
-            [1.0, 0.0, 2.0],
-            [3.0, 2.0, 0.0],
+            [0.0, 1.0, 9.0],
+            [1.0, 0.0, 4.0],
+            [9.0, 4.0, 0.0],
         ]);
 
         $gradient = $this->invokeGradient($embedder, $p, $y, $distances);
@@ -225,9 +230,9 @@ class TSNETest extends TestCase
             [0.0, -1.0],
         ]);
 
-        $pwMethod = new ReflectionMethod(TSNE::class, 'pairwiseDistances');
+        $pwMethod = new ReflectionMethod(TSNE::class, 'squaredPairwiseDistances');
         $pwMethod->setAccessible(true);
-        $distances = Matrix::quick($pwMethod->invokeArgs($this->embedder, [$y->asArray()]));
+        $distances = $pwMethod->invokeArgs($this->embedder, [$y]);
 
         $codeGradient = $this->invokeGradient($this->embedder, $p, $y, $distances);
 
@@ -269,13 +274,20 @@ class TSNETest extends TestCase
      */
     public function affinities() : void
     {
-        $embedder = new TSNE(1, 10.0, 2, 12.0, 500, 1e-7, 10, new Euclidean());
+        $embedder = new TSNE(
+            dimensions: 1,
+            rate: 10.0,
+            perplexity: 2,
+            exaggeration: 12.0,
+            epochs: 500,
+            minGradient: 1e-7
+        );
 
         $distances = [
-            [0.0, 1.0, 2.0, 3.0],
-            [1.0, 0.0, 1.0, 2.0],
-            [2.0, 1.0, 0.0, 1.0],
-            [3.0, 2.0, 1.0, 0.0],
+            [0.0, 1.0, 4.0, 9.0],
+            [1.0, 0.0, 1.0, 4.0],
+            [4.0, 1.0, 0.0, 1.0],
+            [9.0, 4.0, 1.0, 0.0],
         ];
 
         $affinities = $this->invokeAffinities($embedder, $distances);
@@ -393,10 +405,10 @@ class TSNETest extends TestCase
     public function testAffinitiesNormalize() : void
     {
         $distances = [
-            [0.0, 1.0, 2.0, 3.0],
-            [1.0, 0.0, 1.0, 2.0],
-            [2.0, 1.0, 0.0, 1.0],
-            [3.0, 2.0, 1.0, 0.0],
+            [0.0, 1.0, 4.0, 9.0],
+            [1.0, 0.0, 1.0, 4.0],
+            [4.0, 1.0, 0.0, 1.0],
+            [9.0, 4.0, 1.0, 0.0],
         ];
 
         $affinities = $this->invokeAffinities($this->embedder, $distances);
@@ -425,9 +437,9 @@ class TSNETest extends TestCase
         ]);
 
         $distances = Matrix::quick([
-            [0.0, 1.0, 2.0],
+            [0.0, 1.0, 4.0],
             [1.0, 0.0, 1.0],
-            [2.0, 1.0, 0.0],
+            [4.0, 1.0, 0.0],
         ]);
 
         $rows = $this->invokeGradient($this->embedder, $p, $y, $distances)->asArray();
@@ -454,9 +466,9 @@ class TSNETest extends TestCase
         ]);
 
         $distances = Matrix::quick([
-            [0.0, 1.0, 2.0],
+            [0.0, 1.0, 4.0],
             [1.0, 0.0, 1.0],
-            [2.0, 1.0, 0.0],
+            [4.0, 1.0, 0.0],
         ]);
 
         $this->assertGreaterThan(
@@ -492,7 +504,7 @@ class TSNETest extends TestCase
 
         $method->setAccessible(true);
 
-        return $method->invokeArgs($embedder, [$distances]);
+        return $method->invokeArgs($embedder, [Matrix::quick($distances)]);
     }
 
     /**
@@ -510,14 +522,13 @@ class TSNETest extends TestCase
 
         $dofs = (int) $prop->getValue($this->embedder);
 
-        $pwMethod = new ReflectionMethod(TSNE::class, 'pairwiseDistances');
+        $pwMethod = new ReflectionMethod(TSNE::class, 'squaredPairwiseDistances');
 
         $pwMethod->setAccessible(true);
 
-        $distances = Matrix::quick($pwMethod->invokeArgs($this->embedder, [$y->asArray()]));
+        $distances = $pwMethod->invokeArgs($this->embedder, [$y]);
 
-        $base = $distances->square()
-            ->divide($dofs)
+        $base = $distances->divide($dofs)
             ->add(1.0);
 
         $kernel = $base->pow((1.0 + $dofs) / -2.0);

--- a/tests/Transformers/TSNETest.php
+++ b/tests/Transformers/TSNETest.php
@@ -522,7 +522,7 @@ class TSNETest extends TestCase
 
         $dofs = (int) $prop->getValue($this->embedder);
 
-        $pwMethod = new ReflectionMethod(TSNE::class, 'squaredPairwiseDistances');
+        $pwMethod = new ReflectionMethod(TSNE::class, 'pairwiseDistances');
 
         $pwMethod->setAccessible(true);
 


### PR DESCRIPTION
What changed (src/Transformers/TSNE.php)

- Removed the configurable distance kernel (ctor param, property, compatibility() delegation, __toString) — squared distance only, compatibility() returns continuous.
- squaredPairwiseDistances(Matrix) vectorized via ||a−b||² = ||a||²+||b||²−2a·b: one matmul + column/row-vector scaling (returns squared distances as a Matrix).
- affinities(Matrix) consumes precomputed squared distances — no distance ** 2 recomputed inside the up-to-100-pass beta search.
- gradient() collapsed the m-row matmul loop into a single (diag(rowSums) − pqd) @ y via multiplyColumnVector($rowSums)->subtract($pqd->matmul($y)); replaced the two pow() calls with a single reciprocal() (+ alias when dofs === 1, the common case) and skipped the ÷dofs when dofs is 1.

| Run | Time | Peak memory |
| -- | -- | -- |
| Before (pure PHP) | 267.102s | 168.675 MB |
| After (Tensor-vectorized) | 112.970s | 147.357 MB |
| Speedup | 2.36× | −12.6% |