### PR TITLE
Swoole num workers configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
     - Added Hard Sigmoid, Hard SiLU, and ReLU6 activation functions
     - Added He Normal, Le Cun Normal, Truncated Normal, Xavier 1 & 2 Normal
     - Cross Entropy loss function now split into Binary and Multiclass
+    - Parallel Backends now default to max physical cores not logical
     
 - 2.5.11
     - Optimize DBSCAN inference

--- a/src/Backends/Swoole.php
+++ b/src/Backends/Swoole.php
@@ -6,6 +6,7 @@ use Rubix\ML\Backends\Tasks\Task;
 use Rubix\ML\Helpers\CPU;
 use Rubix\ML\Helpers\Params;
 use Rubix\ML\Specifications\ExtensionIsLoaded;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use RuntimeException;
 use Swoole\Atomic;
 use Swoole\Process;
@@ -28,11 +29,11 @@ class Swoole implements Backend
     protected array $queue = [];
 
     /**
-     * The number of CPU cores available to the backend.
+     * The number of workers available to the backend.
      *
      * @var int
      */
-    protected int $numCpus;
+    protected int $workers;
 
     /**
      * Whether the igbinary extension is loaded.
@@ -41,15 +42,24 @@ class Swoole implements Backend
      */
     protected bool $hasIgbinary;
 
-    public function __construct()
+    /**
+     * @param int|null $workers
+     * @throws InvalidArgumentException
+     */
+    public function __construct(?int $workers = null)
     {
+        if (isset($workers) and $workers < 1) {
+            throw new InvalidArgumentException('Number of workers'
+                . " must be greater than 0, $workers given.");
+        }
+
         ExtensionIsLoaded::with('swoole')->check();
 
-        $numCpus = function_exists('swoole_cpu_num') ? swoole_cpu_num() : CPU::cores();
+        $workers ??= function_exists('swoole_cpu_num') ? swoole_cpu_num() : CPU::cores();
 
         $hasIgbinary = ExtensionIsLoaded::with('igbinary')->passes();
 
-        $this->numCpus = $numCpus;
+        $this->workers = $workers;
         $this->hasIgbinary = $hasIgbinary;
     }
 
@@ -122,7 +132,7 @@ class Swoole implements Backend
 
             $workerProcesses[$index] = $workerProcess;
 
-            $currentCpu = ($currentCpu + 1) % $this->numCpus;
+            $currentCpu = ($currentCpu + 1) % $this->workers;
         }
 
         run(function () use ($maxMessageLength, &$results, $workerProcesses) {
@@ -205,6 +215,6 @@ class Swoole implements Backend
      */
     public function __toString() : string
     {
-        return "Swoole (cpus: {$this->numCpus}, igbinary: " . Params::toString($this->hasIgbinary) . ')';
+        return "Swoole (workers: {$this->workers})";
     }
 }

--- a/src/Helpers/CPU.php
+++ b/src/Helpers/CPU.php
@@ -32,14 +32,14 @@ class CPU
     protected const CPU_INFO = '/proc/cpuinfo';
 
     /**
-     * The regular expression used to extract the core count.
+     * The regular expression used to split the cpuinfo output into blocks.
      *
      * @var literal-string
      */
-    protected const CORE_REGEX = '/^processor/m';
+    protected const PROCESSOR_REGEX = '/\n(?=processor\s*:)/';
 
     /**
-     * Return the number of cpu cores or 0 if unable to detect.
+     * Return the number of physical cpu cores or 0 if unable to detect.
      *
      * @throws RuntimeException
      * @return int
@@ -55,11 +55,7 @@ class CPU
             case is_readable(self::CPU_INFO):
                 $cpuinfo = file_get_contents(self::CPU_INFO) ?: '';
 
-                $matches = [];
-
-                preg_match_all(self::CORE_REGEX, $cpuinfo, $matches);
-
-                return count($matches[0]);
+                return self::physicalCores($cpuinfo);
 
             default:
                 throw new RuntimeException('Could not detect number'
@@ -83,5 +79,57 @@ class CPU
         }
 
         return $previous;
+    }
+
+    /**
+     * Count the number of unique physical cores in the cpuinfo contents,
+     * falling back to the logical core count if core ids are unavailable.
+     *
+     * @param string $cpuinfo
+     * @return int
+     */
+    protected static function physicalCores(string $cpuinfo) : int
+    {
+        $cores = [];
+        $logical = 0;
+
+        foreach (preg_split(self::PROCESSOR_REGEX, $cpuinfo) as $block) {
+            if (preg_match('/^processor\s*:/m', $block) !== 1) {
+                continue;
+            }
+
+            $physical = self::parseId($block, 'physical id');
+            $core = self::parseId($block, 'core id');
+
+            if ($core === null) {
+                ++$logical;
+
+                continue;
+            }
+
+            $cores["{$physical}-{$core}"] = true;
+        }
+
+        return $cores !== [] ? count($cores) : $logical;
+    }
+
+    /**
+     * Parse a single identifier attribute from a cpuinfo block or null if absent.
+     *
+     * @param string $block
+     * @param string $attribute
+     * @return int|null
+     */
+    protected static function parseId(string $block, string $attribute) : ?int
+    {
+        $matches = [];
+
+        $pattern = '/^\s*' . $attribute . '\s*:\s*(\d+)/m';
+
+        if (preg_match($pattern, $block, $matches) !== 1) {
+            return null;
+        }
+
+        return (int) $matches[1];
     }
 }

--- a/tests/Helpers/CPUTest.php
+++ b/tests/Helpers/CPUTest.php
@@ -15,6 +15,12 @@ use PHPUnit\Framework\TestCase;
 class CPUTest extends TestCase
 {
     #[Test]
+    public function cores() : void
+    {
+        $this->assertGreaterThan(0, CPU::cores());
+    }
+
+    #[Test]
     public function epsilon() : void
     {
         $epsilon = CPU::epsilon();


### PR DESCRIPTION
Before it was max logical CPU cores, now it's default max physical cores with user-configuration. For compute-bound workloads saturating the virtual cores has a negative impact on performance.