### PR TITLE
Fix Adaboost proba() probability normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - 2.5.12
+    - Fix Adaboost proba() probability normalization
     - Optimize minmax operations
     - Optimize Diagonal distance kernel
 

--- a/src/Classifiers/AdaBoost.php
+++ b/src/Classifiers/AdaBoost.php
@@ -22,11 +22,11 @@ use Rubix\ML\Exceptions\InvalidArgumentException;
 use Rubix\ML\Exceptions\RuntimeException;
 use Generator;
 
+use function Rubix\ML\logsumexp;
 use function count;
 use function is_nan;
 use function array_fill;
 use function array_fill_keys;
-use function array_sum;
 use function get_object_vars;
 use function round;
 use function max;
@@ -461,12 +461,12 @@ class AdaBoost implements Estimator, Learner, Probabilistic, Verbose, Persistabl
         $probabilities = [];
 
         foreach ($scores as $influences) {
-            $total = array_sum($influences) ?: EPSILON;
+            $total = logsumexp($influences);
 
             $dist = [];
 
             foreach ($influences as $class => $influence) {
-                $dist[$class] = $influence / $total;
+                $dist[$class] = exp($influence - $total);
             }
 
             $probabilities[] = $dist;

--- a/tests/Classifiers/AdaBoostTest.php
+++ b/tests/Classifiers/AdaBoostTest.php
@@ -20,6 +20,8 @@ use Rubix\ML\Exceptions\InvalidArgumentException;
 use Rubix\ML\Exceptions\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
+use function Rubix\ML\argmax;
+
 /**
  * @group Classifiers
  * @covers \Rubix\ML\Classifiers\AdaBoost
@@ -175,6 +177,54 @@ class AdaBoostTest extends TestCase
         $predictions = $this->estimator->predict($testing);
 
         $score = $this->metric->score($predictions, $testing->labels());
+
+        $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
+    }
+
+    /**
+     * @test
+     */
+    public function trainPredictProba() : void
+    {
+        $this->estimator->setLogger(new BlackHole());
+
+        $training = $this->generator->generate(self::TRAIN_SIZE);
+        $testing = $this->generator->generate(self::TEST_SIZE);
+
+        $this->estimator->train($training);
+
+        $this->assertTrue($this->estimator->trained());
+
+        $probabilities = $this->estimator->proba($testing);
+
+        $this->assertIsArray($probabilities);
+        $this->assertCount(self::TEST_SIZE, $probabilities);
+
+        $labels = $testing->labels();
+
+        $correct = 0;
+
+        foreach ($probabilities as $offset => $classProbabilities) {
+            $this->assertIsArray($classProbabilities);
+
+            $sum = 0.0;
+
+            foreach ($classProbabilities as $probability) {
+                $this->assertIsNumeric($probability);
+                $this->assertGreaterThanOrEqual(0.0, $probability);
+                $this->assertLessThanOrEqual(1.0, $probability);
+
+                $sum += $probability;
+            }
+
+            $this->assertEqualsWithDelta(1.0, $sum, 1e-9);
+
+            if (argmax($classProbabilities) === $labels[$offset]) {
+                ++$correct;
+            }
+        }
+
+        $score = $correct / self::TEST_SIZE;
 
         $this->assertGreaterThanOrEqual(self::MIN_SCORE, $score);
     }


### PR DESCRIPTION
src/Classifiers/AdaBoost.php:568-575 — proba() linearly normalizes raw per-learner influence, which for k≥3 classes can produce negative "probabilities" that don't sum to 1.$total = array_sum($influences) ?: EPSILON;
$dist[$class] = $influence / $total;

Influence is log((1-loss)/loss) per line 448-450 and is negative whenever loss > 0.5. With k ≥ 3, losses between 0.5 and 1−1/k are allowed, so some per-class values are negative and array_sum can be ≤ 0 (triggering the ?: EPSILON branch) → returned distribution is invalid. predict() (argmax on raw scores at line 553) is unaffected.
Expected: softmax of the accumulated per-class scores. Actual: linear normalization.