### PR TITLE
Fix SQL Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+- 2.5.13
+    - Fix SQL Table offset syntax to work with Postgres
+    - Prevent SQL Table injection attack
+
 - 2.5.12
     - Fix Adaboost proba() probability normalization
     - Optimize minmax operations

--- a/src/Extractors/SQLTable.php
+++ b/src/Extractors/SQLTable.php
@@ -11,6 +11,7 @@ use PDO;
 use function Rubix\ML\iterator_first;
 use function count;
 use function array_keys;
+use function preg_match;
 
 /**
  * SQL Table
@@ -25,6 +26,11 @@ use function array_keys;
  */
 class SQLTable implements Extractor
 {
+    /**
+     * The regex pattern for validating table names.
+     */
+    protected const string TABLE_NAME_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/';
+
     /**
      * The PDO connection to the database.
      *
@@ -60,13 +66,17 @@ class SQLTable implements Extractor
             throw new InvalidArgumentException('Table name cannot be empty.');
         }
 
+        if (!preg_match(self::TABLE_NAME_PATTERN, $table)) {
+            throw new InvalidArgumentException("Table name '{$table}' is not a valid identifier.");
+        }
+
         if ($batchSize < 1) {
             throw new InvalidArgumentException('Batch size must be'
                 . " greater than 0, $batchSize given.");
         }
 
         $this->connection = $connection;
-        $this->table = $connection->quote($table);
+        $this->table = $table;
         $this->batchSize = $batchSize;
     }
 
@@ -87,7 +97,7 @@ class SQLTable implements Extractor
      */
     public function getIterator() : Traversable
     {
-        $query = "SELECT * FROM {$this->table} LIMIT :offset, {$this->batchSize}";
+        $query = "SELECT * FROM {$this->table} LIMIT {$this->batchSize} OFFSET :offset";
 
         $statement = $this->connection->prepare($query);
 

--- a/src/Extractors/SQLTable.php
+++ b/src/Extractors/SQLTable.php
@@ -26,10 +26,7 @@ use function preg_match;
  */
 class SQLTable implements Extractor
 {
-    /**
-     * The regex pattern for validating table names.
-     */
-    protected const string TABLE_NAME_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/';
+    protected const TABLE_NAME_PATTERN = '/^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/';
 
     /**
      * The PDO connection to the database.

--- a/tests/Extractors/SQLTableTest.php
+++ b/tests/Extractors/SQLTableTest.php
@@ -4,6 +4,7 @@ namespace Rubix\ML\Tests\Extractors;
 
 use Rubix\ML\Extractors\SQLTable;
 use Rubix\ML\Extractors\Extractor;
+use Rubix\ML\Exceptions\InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use IteratorAggregate;
 use Traversable;
@@ -67,5 +68,17 @@ class SQLTableTest extends TestCase
         $header = $this->extractor->header();
 
         $this->assertEquals($expected, $header);
+    }
+
+    /**
+     * @test
+     */
+    public function rejectInvalidIdentifier() : void
+    {
+        $connection = new PDO('sqlite::memory:');
+
+        $this->expectException(InvalidArgumentException::class);
+
+        new SQLTable($connection, "pets'; DROP TABLE users; --");
     }
 }


### PR DESCRIPTION
- Removed $connection->quote($table) (produced a string literal like 'pets' in FROM → MySQL ERROR 1149)
- Added strict identifier whitelist: /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)?$/ → throws InvalidArgumentException otherwise (src/Extractors/SQLTable.php:64-66)
- Query changed to portable LIMIT {$batchSize} OFFSET :offset (valid on MySQL, SQLite, PostgreSQL), replacing the MySQL/SQLite-only LIMIT :offset, N (src/Extractors/SQLTable.php:95)