### PR TITLE
Fix Image Rotator

### DIFF
--- a/src/Transformers/ImageRotator.php
+++ b/src/Transformers/ImageRotator.php
@@ -5,6 +5,7 @@ namespace Rubix\ML\Transformers;
 use Rubix\ML\DataType;
 use Rubix\ML\Specifications\ExtensionIsLoaded;
 use Rubix\ML\Exceptions\InvalidArgumentException;
+use Rubix\ML\Exceptions\RuntimeException;
 
 use function rand;
 use function array_walk;
@@ -24,7 +25,7 @@ use function getrandmax;
 class ImageRotator implements Transformer
 {
     /**
-     * The color of the area of the image filled in after rotation and cropping.
+     * The color of the area of the image filled in after rotation.
      *
      * @var int
      */
@@ -90,11 +91,12 @@ class ImageRotator implements Transformer
     }
 
     /**
-     * Randomly rotates and crops the images in a sample to their original size.
+     * Randomly rotates the images in a sample and resizes them back to their original size.
      *
      * @internal
      *
      * @param list<mixed> $sample
+     * @throws RuntimeException
      */
     protected function rotateAndCrop(array &$sample) : void
     {
@@ -112,12 +114,30 @@ class ImageRotator implements Transformer
                     $newWidth = imagesx($rotated);
 
                     if ($originalHeight !== $newHeight or $originalWidth !== $newWidth) {
-                        $rotated = imagecrop($rotated, [
-                            'x' => $newWidth / 2 - $originalWidth / 2,
-                            'y' => $newHeight / 2 - $originalHeight / 2,
-                            'width' => $originalWidth,
-                            'height' => $originalHeight
-                        ]);
+                        $resized = imagecreatetruecolor($originalWidth, $originalHeight);
+
+                        if (!$resized) {
+                            throw new RuntimeException('Could not create placeholder image.');
+                        }
+
+                        $success = imagecopyresized(
+                            $resized,
+                            $rotated,
+                            0,
+                            0,
+                            0,
+                            0,
+                            $originalWidth,
+                            $originalHeight,
+                            $newWidth,
+                            $newHeight
+                        );
+
+                        if (!$success) {
+                            throw new RuntimeException('Failed to resize image back to its original size.');
+                        }
+
+                        $rotated = $resized;
                     }
 
                     $value = $rotated;

--- a/src/Transformers/ImageRotator.php
+++ b/src/Transformers/ImageRotator.php
@@ -120,7 +120,7 @@ class ImageRotator implements Transformer
                             throw new RuntimeException('Could not create placeholder image.');
                         }
 
-                        $success = imagecopyresized(
+                        $success = imagecopyresampled(
                             $resized,
                             $rotated,
                             0,
@@ -134,8 +134,12 @@ class ImageRotator implements Transformer
                         );
 
                         if (!$success) {
+                            imagedestroy($resized);
+
                             throw new RuntimeException('Failed to resize image back to its original size.');
                         }
+
+                        imagedestroy($rotated);
 
                         $rotated = $resized;
                     }

--- a/tests/Transformers/ImageRotatorTest.php
+++ b/tests/Transformers/ImageRotatorTest.php
@@ -63,12 +63,12 @@ class ImageRotatorTest extends TestCase
      */
     public function transformWideImage90Degrees() : void
     {
-        $source = imagecreatetruecolor(80, 40);
-        $dataset = Unlabeled::quick([
-            [$source, 'whatever', 69],
-        ]);
-
         foreach ([90.0, 270.0] as $degrees) {
+            $source = imagecreatetruecolor(80, 40);
+            $dataset = Unlabeled::quick([
+                [$source, 'whatever', 69],
+            ]);
+
             $mock = $this->createPartialMock(ImageRotator::class, ['rotationAngle']);
             $mock->method('rotationAngle')->will($this->returnValue($degrees));
 
@@ -79,7 +79,11 @@ class ImageRotatorTest extends TestCase
             $this->assertSame(40, imagesy($sample[0]));
             $this->assertSame('whatever', $sample[1]);
 
-            imagedestroy($sample[0]);
+            if ($sample[0] !== $source) {
+                imagedestroy($sample[0]);
+            }
+
+            imagedestroy($source);
         }
     }
 

--- a/tests/Transformers/ImageRotatorTest.php
+++ b/tests/Transformers/ImageRotatorTest.php
@@ -61,6 +61,97 @@ class ImageRotatorTest extends TestCase
     /**
      * @test
      */
+    public function transformWideImage90Degrees() : void
+    {
+        $source = imagecreatetruecolor(80, 40);
+        $dataset = Unlabeled::quick([
+            [$source, 'whatever', 69],
+        ]);
+
+        foreach ([90.0, 270.0] as $degrees) {
+            $mock = $this->createPartialMock(ImageRotator::class, ['rotationAngle']);
+            $mock->method('rotationAngle')->will($this->returnValue($degrees));
+
+            $dataset->apply($mock);
+            $sample = $dataset->sample(0);
+
+            $this->assertSame(80, imagesx($sample[0]));
+            $this->assertSame(40, imagesy($sample[0]));
+            $this->assertSame('whatever', $sample[1]);
+
+            imagedestroy($sample[0]);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function transformTallImage90Degrees() : void
+    {
+        $source = imagecreatetruecolor(20, 100);
+        $dataset = Unlabeled::quick([
+            [$source, 'whatever', 69],
+        ]);
+
+        foreach ([90.0, 270.0] as $degrees) {
+            $mock = $this->createPartialMock(ImageRotator::class, ['rotationAngle']);
+            $mock->method('rotationAngle')->will($this->returnValue($degrees));
+
+            $dataset->apply($mock);
+            $sample = $dataset->sample(0);
+
+            $this->assertSame(20, imagesx($sample[0]));
+            $this->assertSame(100, imagesy($sample[0]));
+            $this->assertSame('whatever', $sample[1]);
+
+            imagedestroy($sample[0]);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function transformExtremeRatioImage90Degrees() : void
+    {
+        $source = imagecreatetruecolor(200, 5);
+        $dataset = Unlabeled::quick([
+            [$source, 'whatever', 69],
+        ]);
+
+        $mock = $this->createPartialMock(ImageRotator::class, ['rotationAngle']);
+        $mock->method('rotationAngle')->will($this->returnValue(90.0));
+
+        $dataset->apply($mock);
+        $sample = $dataset->sample(0);
+
+        $this->assertSame(200, imagesx($sample[0]));
+        $this->assertSame(5, imagesy($sample[0]));
+    }
+
+    /**
+     * @test
+     */
+    public function transformSquareImage45Degrees() : void
+    {
+        $source = imagecreatetruecolor(32, 32);
+        $dataset = Unlabeled::quick([
+            [$source, 'whatever', 69],
+        ]);
+
+        $mock = $this->createPartialMock(ImageRotator::class, ['rotationAngle']);
+        $mock->method('rotationAngle')->will($this->returnValue(45.0));
+
+        $dataset->apply($mock);
+        $sample = $dataset->sample(0);
+
+        $this->assertSame(32, imagesx($sample[0]));
+        $this->assertSame(32, imagesy($sample[0]));
+        $this->assertSame('whatever', $sample[1]);
+    }
+
+    /**
+     * @test
+     */
     public function transform() : void
     {
         $dataset = Unlabeled::quick([


### PR DESCRIPTION
Fix in src/Transformers/ImageRotator.php:114-132 — Replaced the imagecrop call (whose box went negative when width/height swapped) with a resize onto a new canvas of original dimensions. This:

- Always yields the original W×H (matching the documented "original size" contract).
- Never returns false, so can't clobber the sample.
- Throws Rubix\ML\Exceptions\RuntimeException if GD allocation fails — consistent with ImageResizer.php:118-126.
