### PR TITLE
Fix Column Picker/Filter null columns

### DIFF
--- a/src/Extractors/ColumnFilter.php
+++ b/src/Extractors/ColumnFilter.php
@@ -4,6 +4,9 @@ namespace Rubix\ML\Extractors;
 
 use Traversable;
 
+use function array_key_exists;
+use function array_values;
+
 /**
  * Column Filter
  *

--- a/src/Extractors/ColumnFilter.php
+++ b/src/Extractors/ColumnFilter.php
@@ -46,7 +46,7 @@ class ColumnFilter implements Extractor
     {
         foreach ($this->iterator as $record) {
             foreach ($this->columns as $column) {
-                if (isset($record[$column])) {
+                if (array_key_exists($column, $record)) {
                     unset($record[$column]);
                 }
             }

--- a/src/Extractors/ColumnPicker.php
+++ b/src/Extractors/ColumnPicker.php
@@ -54,7 +54,7 @@ class ColumnPicker implements Extractor
             $picked = [];
 
             foreach ($this->columns as $column) {
-                if (!isset($record[$column])) {
+                if (!array_key_exists($column, $record)) {
                     throw new RuntimeException("Column '$column' not found"
                         . " at row offset $i.");
                 }

--- a/src/Extractors/ColumnPicker.php
+++ b/src/Extractors/ColumnPicker.php
@@ -5,6 +5,9 @@ namespace Rubix\ML\Extractors;
 use Rubix\ML\Exceptions\RuntimeException;
 use Traversable;
 
+use function array_key_exists;
+use function array_values;
+
 /**
  * Column Picker
  *

--- a/tests/Extractors/ColumnFilterTest.php
+++ b/tests/Extractors/ColumnFilterTest.php
@@ -59,4 +59,26 @@ class ColumnFilterTest extends TestCase
 
         $this->assertEquals($expected, $records);
     }
+
+    /**
+     * @test
+     */
+    public function extractNullColumn() : void
+    {
+        $iterable = (function () {
+            yield [
+                'attitude' => 'nice', 'texture' => null, 'class' => 'not monster', 'rating' => '4',
+            ];
+        })();
+
+        $extractor = new ColumnFilter($iterable, ['texture']);
+
+        $expected = [
+            ['attitude' => 'nice', 'class' => 'not monster', 'rating' => '4'],
+        ];
+
+        $records = iterator_to_array($extractor, false);
+
+        $this->assertEquals($expected, $records);
+    }
 }

--- a/tests/Extractors/ColumnPickerTest.php
+++ b/tests/Extractors/ColumnPickerTest.php
@@ -59,4 +59,26 @@ class ColumnPickerTest extends TestCase
 
         $this->assertEquals($expected, $records);
     }
+
+    /**
+     * @test
+     */
+    public function extractNullColumn() : void
+    {
+        $iterable = (function () {
+            yield [
+                'attitude' => 'nice', 'texture' => null, 'class' => 'not monster', 'rating' => '4',
+            ];
+        })();
+
+        $extractor = new ColumnPicker($iterable, ['texture']);
+
+        $expected = [
+            ['texture' => null],
+        ];
+
+        $records = iterator_to_array($extractor, false);
+
+        $this->assertEquals($expected, $records);
+    }
 }


### PR DESCRIPTION
- src/Extractors/ColumnPicker.php:57 — isset($record[$column]) → array_key_exists($column, $record) so null-valued columns are no longer reported as "not found"
- src/Extractors/ColumnFilter.php:49 — same swap so null-valued columns are properly removed instead of silently kept
- Added extractNullColumn() regression tests to both tests/Extractors/ColumnPickerTest.php and tests/Extractors/ColumnFilterTest.php