### PR TITLE
Fix Random Projector magnitudes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - 2.5.14
     - Fix Report and Tuple null values
+    - Fix Random Projector mangitudes
+    - Prevent division by zero in Sparse Random Projector
 
 - 2.5.13
     - Fix SQL Table offset syntax to work with Postgres

--- a/src/Transformers/GaussianRandomProjector.php
+++ b/src/Transformers/GaussianRandomProjector.php
@@ -11,6 +11,8 @@ use Rubix\ML\Specifications\SamplesAreCompatibleWithTransformer;
 use Rubix\ML\Exceptions\InvalidArgumentException;
 use Rubix\ML\Exceptions\RuntimeException;
 
+use function sqrt;
+
 /**
  * Gaussian Random Projector
  *
@@ -117,7 +119,8 @@ class GaussianRandomProjector implements Transformer, Stateful, Persistable
     {
         SamplesAreCompatibleWithTransformer::with($dataset, $this)->check();
 
-        $this->r = Matrix::gaussian($dataset->numFeatures(), $this->dimensions);
+        $this->r = Matrix::gaussian($dataset->numFeatures(), $this->dimensions)
+            ->divideScalar(sqrt($this->dimensions));
     }
 
     /**

--- a/src/Transformers/SparseRandomProjector.php
+++ b/src/Transformers/SparseRandomProjector.php
@@ -79,7 +79,7 @@ class SparseRandomProjector extends GaussianRandomProjector
             $density = 1.0 - $this->sparsity;
         }
 
-        $dHat = sqrt(1.0 / $density);
+        $dHat = 1.0 / sqrt($density * $this->dimensions);
 
         $distribution = [
             [-$dHat, 0.5 * $density],

--- a/src/Transformers/SparseRandomProjector.php
+++ b/src/Transformers/SparseRandomProjector.php
@@ -51,9 +51,9 @@ class SparseRandomProjector extends GaussianRandomProjector
      */
     public function __construct(int $dimensions, ?float $sparsity = self::TWO_THIRDS)
     {
-        if ($sparsity < 0.0 or $sparsity > 1.0) {
+        if ($sparsity < 0.0 or $sparsity >= 1.0) {
             throw new InvalidArgumentException('Sparsity must be'
-                . " between 0 and 1, $sparsity given.");
+                . " between 0 (inclusive) and 1 (exclusive), $sparsity given.");
         }
 
         parent::__construct($dimensions);

--- a/tests/ReportTest.php
+++ b/tests/ReportTest.php
@@ -109,6 +109,6 @@ class ReportTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Attribute with key nonexistent not found.');
 
-        $this->results['nonexistent'];
+        $appeaseStan = $this->results['nonexistent'];
     }
 }

--- a/tests/Transformers/GaussianRandomProjectorTest.php
+++ b/tests/Transformers/GaussianRandomProjectorTest.php
@@ -99,17 +99,36 @@ class GaussianRandomProjectorTest extends TestCase
      */
     public function fitTransform() : void
     {
+        $this->assertCount(20, $this->generator->generate(1)->sample(0));
+
         $dataset = $this->generator->generate(30);
 
         $this->transformer->fit($dataset);
 
         $this->assertTrue($this->transformer->fitted());
 
-        $sample = $this->generator->generate(1)
-            ->apply($this->transformer)
-            ->sample(0);
+        $dataset = $this->generator->generate(30);
 
-        $this->assertCount(5, $sample);
+        $originals = $dataset->samples();
+
+        $dataset->apply($this->transformer);
+
+        $projected = $dataset->samples();
+
+        $this->assertCount(5, $projected[0]);
+
+        $meanFactor = 0.0;
+
+        foreach ($originals as $idx => $original) {
+            $denominator = $this->squaredNorm($original);
+
+            $meanFactor += $this->squaredNorm($projected[$idx]) / $denominator;
+        }
+
+        $meanFactor /= count($originals);
+
+        $this->assertGreaterThan(0.7, $meanFactor, 'Projector does not preserve magnitude (too small).');
+        $this->assertLessThan(1.3, $meanFactor, 'Projector does not preserve magnitude (too large).');
     }
 
     /**
@@ -122,5 +141,20 @@ class GaussianRandomProjectorTest extends TestCase
         $samples = $this->generator->generate(1)->samples();
 
         $this->transformer->transform($samples);
+    }
+
+    /**
+     * @param array<float> $x
+     * @return float
+     */
+    protected function squaredNorm(array $x) : float
+    {
+        $sum = 0.0;
+
+        foreach ($x as $value) {
+            $sum += $value ** 2;
+        }
+
+        return $sum;
     }
 }

--- a/tests/Transformers/SparseRandomProjectorTest.php
+++ b/tests/Transformers/SparseRandomProjectorTest.php
@@ -61,23 +61,34 @@ class SparseRandomProjectorTest extends TestCase
     {
         $this->assertCount(10, $this->generator->generate(1)->sample(0));
 
-        $this->transformer->fit($this->generator->generate(30));
+        $dataset = $this->generator->generate(30);
+
+        $this->transformer->fit($dataset);
 
         $this->assertTrue($this->transformer->fitted());
 
-        $expected = [
-            3.8861419746435,
-            -17.801078083484,
-            0.29819783331323,
-            -12.191560356574,
-        ];
+        $dataset = $this->generator->generate(30);
 
-        $sample = $this->generator->generate(1)
-            ->apply($this->transformer)
-            ->sample(0);
+        $originals = $dataset->samples();
 
-        $this->assertCount(4, $sample);
-        $this->assertEqualsWithDelta($expected, $sample, 1e-8);
+        $dataset->apply($this->transformer);
+
+        $projected = $dataset->samples();
+
+        $this->assertCount(4, $projected[0]);
+
+        $meanFactor = 0.0;
+
+        foreach ($originals as $idx => $original) {
+            $denominator = $this->squaredNorm($original);
+
+            $meanFactor += $this->squaredNorm($projected[$idx]) / $denominator;
+        }
+
+        $meanFactor /= count($originals);
+
+        $this->assertGreaterThan(0.7, $meanFactor, 'Projector does not preserve magnitude (too small).');
+        $this->assertLessThan(1.3, $meanFactor, 'Projector does not preserve magnitude (too large).');
     }
 
     /**
@@ -90,5 +101,20 @@ class SparseRandomProjectorTest extends TestCase
         $samples = $this->generator->generate(1)->samples();
 
         $this->transformer->transform($samples);
+    }
+
+    /**
+     * @param array<float> $x
+     * @return float
+     */
+    protected function squaredNorm(array $x) : float
+    {
+        $sum = 0.0;
+
+        foreach ($x as $value) {
+            $sum += $value ** 2;
+        }
+
+        return $sum;
     }
 }

--- a/tests/TupleTest.php
+++ b/tests/TupleTest.php
@@ -75,17 +75,7 @@ class TupleTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Element at offset 100 not found.');
 
-        $this->tuple[100];
-    }
-
-    /**
-     * @test
-     */
-    public function immutability() : void
-    {
-        $this->expectException(RuntimeException::class);
-
-        $this->tuple[0] = 1;
+        $appeaseStan = $this->tuple[100];
     }
 
     /**


### PR DESCRIPTION
Transformers/GaussianRandomProjector.php:120, SparseRandomProjector.php:82 — [upstream-check] missing the JL 1/sqrt(k) normalization (preserves ratios, not absolute magnitude).

- GaussianRandomProjector — matrix scaled by ÷ √k at fit (src/Transformers/GaussianRandomProjector.php:122)
- SparseRandomProjector — dHat changed to 1/√(density · k) (src/Transformers/SparseRandomProjector.php:82)