### PR TITLE
MLP Smart final layer projections

### DIFF
--- a/src/Classifiers/MultilayerPerceptron.php
+++ b/src/Classifiers/MultilayerPerceptron.php
@@ -50,6 +50,7 @@ use function array_map;
 use function is_dir;
 use function uniqid;
 use function sys_get_temp_dir;
+use function array_reverse;
 
 /**
  * Multilayer Perceptron
@@ -409,9 +410,11 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
 
         $outputWidth = $dataset->numFeatures();
 
-        foreach ($hiddenLayers as $layer) {
+        foreach (array_reverse($hiddenLayers) as $layer) {
             if ($layer instanceof Dense) {
                 $outputWidth = $layer->width();
+
+                break;
             }
         }
 

--- a/src/Classifiers/MultilayerPerceptron.php
+++ b/src/Classifiers/MultilayerPerceptron.php
@@ -407,7 +407,23 @@ class MultilayerPerceptron implements Estimator, Learner, Online, Probabilistic,
 
         $hiddenLayers = $this->hiddenLayers;
 
-        $hiddenLayers[] = new Dense(count($classes), 0.0, true, new Xavier1());
+        $outputWidth = $dataset->numFeatures();
+
+        foreach ($hiddenLayers as $layer) {
+            if ($layer instanceof Dense) {
+                $outputWidth = $layer->width();
+            }
+        }
+
+        if ($outputWidth !== count($classes)) {
+            $hiddenLayers[] = new Dense(count($classes), 0.0, true, new Xavier1());
+
+            if ($this->logger) {
+                $this->logger->info('Final hidden layer dimensionality mismatch, '
+                    . 'adding projection layer to match output width of '
+                    . count($classes) . ' classes.');
+            }
+        }
 
         $this->network = new FeedForward(
             new Placeholder1D($dataset->numFeatures()),

--- a/src/Regressors/MLPRegressor.php
+++ b/src/Regressors/MLPRegressor.php
@@ -386,7 +386,22 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable
 
         $hiddenLayers = $this->hiddenLayers;
 
-        $hiddenLayers[] = new Dense(1, 0.0, true, new Xavier1());
+        $outputWidth = $dataset->numFeatures();
+
+        foreach ($hiddenLayers as $layer) {
+            if ($layer instanceof Dense) {
+                $outputWidth = $layer->width();
+            }
+        }
+
+        if ($outputWidth !== 1) {
+            $hiddenLayers[] = new Dense(1, 0.0, true, new Xavier1());
+
+            if ($this->logger) {
+                $this->logger->info('Final hidden layer dimensionality mismatch, '
+                    . 'adding projection layer to match output width of 1.');
+            }
+        }
 
         $this->network = new FeedForward(
             new Placeholder1D($dataset->numFeatures()),

--- a/src/Regressors/MLPRegressor.php
+++ b/src/Regressors/MLPRegressor.php
@@ -47,6 +47,7 @@ use function is_nan;
 use function number_format;
 use function uniqid;
 use function sys_get_temp_dir;
+use function array_reverse;
 
 /**
  * MLP Regressor
@@ -388,9 +389,11 @@ class MLPRegressor implements Estimator, Learner, Online, Verbose, Persistable
 
         $outputWidth = $dataset->numFeatures();
 
-        foreach ($hiddenLayers as $layer) {
+        foreach (array_reverse($hiddenLayers) as $layer) {
             if ($layer instanceof Dense) {
                 $outputWidth = $layer->width();
+
+                break;
             }
         }
 

--- a/tests/Classifiers/MultilayerPerceptronTest.php
+++ b/tests/Classifiers/MultilayerPerceptronTest.php
@@ -222,6 +222,57 @@ class MultilayerPerceptronTest extends TestCase
     }
 
     #[Test]
+    public function trainSkipsProjectionWhenEffectiveWidthMatches() : void
+    {
+        $estimator = new MultilayerPerceptron(
+            hiddenLayers: [
+                new Dense(8),
+                new Activation(new LeakyReLU()),
+                new Dense(3),
+                new Activation(new LeakyReLU()),
+            ],
+            batchSize: 32,
+            epochs: 1,
+            holdOut: 0
+        );
+
+        $dataset = $this->generator->generate(64);
+
+        $estimator->train($dataset);
+
+        $hidden = $estimator->network()->hidden();
+
+        $this->assertCount(4, $hidden);
+        $this->assertEquals(3, $hidden[3]->width());
+    }
+
+    #[Test]
+    public function trainAppendsProjectionWhenEffectiveWidthMismatches() : void
+    {
+        $estimator = new MultilayerPerceptron(
+            hiddenLayers: [
+                new Dense(8),
+                new Activation(new LeakyReLU()),
+                new Dense(5),
+                new Activation(new LeakyReLU()),
+            ],
+            batchSize: 32,
+            epochs: 1,
+            holdOut: 0
+        );
+
+        $dataset = $this->generator->generate(64);
+
+        $estimator->train($dataset);
+
+        $hidden = $estimator->network()->hidden();
+
+        $this->assertCount(5, $hidden);
+        $this->assertInstanceOf(Dense::class, $hidden[4]);
+        $this->assertEquals(3, $hidden[4]->width());
+    }
+
+    #[Test]
     public function snapshotPathIsTransientAndResolvedLazily() : void
     {
         $this->estimator->setLogger(new BlackHole());

--- a/tests/Regressors/MLPRegressorTest.php
+++ b/tests/Regressors/MLPRegressorTest.php
@@ -200,6 +200,58 @@ class MLPRegressorTest extends TestCase
     }
 
     #[Test]
+    #[TestDox('Train skips projection when effective width matches')]
+    public function trainSkipsProjectionWhenEffectiveWidthMatches() : void
+    {
+        $estimator = new MLPRegressor(
+            hiddenLayers: [
+                new Dense(8),
+                new Activation(new SiLU()),
+                new Dense(1),
+                new Activation(new SiLU()),
+            ],
+            batchSize: 32,
+            epochs: 1,
+            holdOut: 0
+        );
+
+        $dataset = $this->generator->generate(64);
+
+        $estimator->train($dataset);
+
+        $hidden = $estimator->network()->hidden();
+
+        $this->assertCount(4, $hidden);
+        $this->assertEquals(1, $hidden[3]->width());
+    }
+
+    #[Test]
+    #[TestDox('Train appends projection when effective width mismatches')]
+    public function trainAppendsProjectionWhenEffectiveWidthMismatches() : void
+    {
+        $estimator = new MLPRegressor(
+            hiddenLayers: [
+                new Dense(8),
+                new Activation(new SiLU()),
+                new Dense(4),
+            ],
+            batchSize: 32,
+            epochs: 1,
+            holdOut: 0
+        );
+
+        $dataset = $this->generator->generate(64);
+
+        $estimator->train($dataset);
+
+        $hidden = $estimator->network()->hidden();
+
+        $this->assertCount(4, $hidden);
+        $this->assertInstanceOf(Dense::class, $hidden[3]);
+        $this->assertEquals(1, $hidden[3]->width());
+    }
+
+    #[Test]
     #[TestDox('Snapshot path is transient and resolved lazily')]
     public function snapshotPathIsTransientAndResolvedLazily() : void
     {


### PR DESCRIPTION
If the final hidden layer dimensionality does not match the required width, add a projection layer - instead of always assuming a final projection layer.